### PR TITLE
GP-259: Expose builder base path

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -58,6 +58,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestBuilderSetBasePath() = runBlocking {
+        val result = testBuilderSetBasePath()
+        assertTrue(result.success, "Builder Set Base Path test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderAddResource() = runBlocking {
         val result = testBuilderAddResource()
         assertTrue(result.success, "Builder Add Resource test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -829,6 +829,23 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setRemoteUrlNative(JNIE
     return result;
 }
 
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setBasePathNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring basePath) {
+    if (builderPtr == 0 || basePath == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and base path cannot be null");
+        return -1;
+    }
+
+    const char *cbasePath = jstring_to_cstring(env, basePath);
+    if (cbasePath == NULL) {
+        return -1;
+    }
+
+    int result = c2pa_builder_set_base_path((struct C2paBuilder*)(uintptr_t)builderPtr, cbasePath);
+    release_cstring(env, basePath, cbasePath);
+    return result;
+}
+
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring uri, jlong streamPtr) {
     const char *curi = jstring_to_cstring(env, uri);
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -421,6 +421,25 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
     }
 
     /**
+     * Sets the base path used to resolve relative resource references.
+     *
+     * When the manifest definition references resources by relative path, the builder resolves
+     * them against this base directory on the filesystem.
+     *
+     * @param path The base directory for resolving relative resource references
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the base path cannot be set
+     */
+    @Throws(C2PAError::class)
+    fun setBasePath(path: String): Builder {
+        val result = setBasePathNative(ptr, path)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to set base path")
+        }
+        return this
+    }
+
+    /**
      * Adds a resource to the builder.
      *
      * @param uri The URI identifying the resource
@@ -564,6 +583,7 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
     private external fun addActionNative(handle: Long, actionJson: String): Int
     private external fun setNoEmbedNative(handle: Long)
     private external fun setRemoteUrlNative(handle: Long, remoteUrl: String): Int
+    private external fun setBasePathNative(handle: Long, basePath: String): Int
     private external fun addResourceNative(handle: Long, uri: String, streamHandle: Long): Int
     private external fun addIngredientFromStreamNative(
         handle: Long,

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -185,6 +185,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderOperations())
     results.add(builderTests.testBuilderNoEmbed())
     results.add(builderTests.testBuilderRemoteUrl())
+    results.add(builderTests.testBuilderSetBasePath())
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
     results.add(builderTests.testBuilderFromArchive())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -172,6 +172,64 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testBuilderSetBasePath(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Builder Set Base Path") {
+            val manifestJson = TEST_MANIFEST_JSON
+            val baseDir = File.createTempFile("c2pa-base-path", "").let { tmp ->
+                tmp.delete()
+                tmp.mkdirs()
+                tmp
+            }
+
+            try {
+                Builder.fromJson(manifestJson).use { builder ->
+                    // setBasePath is fluent and must not corrupt the builder; a subsequent
+                    // sign should still succeed against the configured base directory.
+                    builder.setBasePath(baseDir.absolutePath)
+
+                    val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                    val sourceStream = ByteArrayStream(sourceImageData)
+                    val fileTest = File.createTempFile("c2pa-base-path-test", ".jpg")
+                    val destStream = FileStream(fileTest)
+
+                    try {
+                        sourceStream.use {
+                            destStream.use {
+                                val certPem = loadResourceAsString("es256_certs")
+                                val keyPem = loadResourceAsString("es256_private")
+                                Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                    val signResult = builder.sign("image/jpeg", sourceStream, destStream, signer)
+                                    val success = signResult.size > 0
+                                    TestResult(
+                                        "Builder Set Base Path",
+                                        success,
+                                        if (success) {
+                                            "Base path set and signing succeeded"
+                                        } else {
+                                            "Signing failed after setting base path"
+                                        },
+                                        "Base dir: ${baseDir.absolutePath}, Sign result size: ${signResult.size}",
+                                    )
+                                }
+                            }
+                        }
+                    } finally {
+                        fileTest.delete()
+                    }
+                }
+            } catch (e: C2PAError) {
+                TestResult(
+                    "Builder Set Base Path",
+                    false,
+                    "Failed to set base path",
+                    e.toString(),
+                )
+            } finally {
+                baseDir.delete()
+            }
+        }
+    }
+
     suspend fun testBuilderAddResource(): TestResult = withContext(Dispatchers.IO) {
         runTest("Builder Add Resource") {
             val manifestJson = TEST_MANIFEST_JSON


### PR DESCRIPTION
Part of GP-252 (umbrella: expose remaining c2pa-rs FFI surface).

Adds `Builder.setBasePath()`, wiring `c2pa_builder_set_base_path` through the JNI bridge so a manifest definition resolves relative resource references against a filesystem directory. Includes a shared Builder test registered in the instrumented suite and test-app.

Linear: https://linear.app/redaranj/issue/GP-259

Verification: compiles (Kotlin + JNI syntax-check); native .so build and instrumented tests pending on-device.