### PR TITLE
GP-258: Expose supported MIME types introspection

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -58,6 +58,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestSupportedMimeTypes() = runBlocking {
+        val result = testSupportedMimeTypes()
+        assertTrue(result.success, "Supported MIME Types test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderAddResource() = runBlocking {
         val result = testBuilderAddResource()
         assertTrue(result.success, "Builder Add Resource test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -175,6 +175,30 @@ static jstring cstring_to_jstring(JNIEnv *env, const char* cstr) {
     return jstr;
 }
 
+// Helper to convert a C string array (as returned by c2pa_*_supported_mime_types)
+// into a Java String[]. Does not free the source array; the caller is responsible.
+static jobjectArray cstring_array_to_jarray(JNIEnv *env, const char *const *items, uintptr_t count) {
+    jclass stringClass = (*env)->FindClass(env, "java/lang/String");
+    if (stringClass == NULL) {
+        check_exception(env);
+        return NULL;
+    }
+    jobjectArray result = (*env)->NewObjectArray(env, (jsize)count, stringClass, NULL);
+    (*env)->DeleteLocalRef(env, stringClass);
+    if (result == NULL) {
+        check_exception(env);
+        return NULL;
+    }
+    for (uintptr_t i = 0; i < count; i++) {
+        jstring item = cstring_to_jstring(env, items[i]);
+        if (item != NULL) {
+            (*env)->SetObjectArrayElement(env, result, (jsize)i, item);
+            (*env)->DeleteLocalRef(env, item);
+        }
+    }
+    return result;
+}
+
 // Thread key destructor - detaches thread when it exits
 static void thread_detach_destructor(void *value) {
     if (value != NULL) {
@@ -749,7 +773,29 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_resourceToStreamNative(
     return (jlong)(uintptr_t)result;
 }
 
+JNIEXPORT jobjectArray JNICALL Java_org_contentauth_c2pa_Reader_supportedMimeTypesNative(JNIEnv *env, jclass clazz) {
+    uintptr_t count = 0;
+    const char *const *types = c2pa_reader_supported_mime_types(&count);
+    if (types == NULL) {
+        return NULL;
+    }
+    jobjectArray result = cstring_array_to_jarray(env, types, count);
+    c2pa_free_string_array(types, count);
+    return result;
+}
+
 // Builder native methods
+JNIEXPORT jobjectArray JNICALL Java_org_contentauth_c2pa_Builder_supportedMimeTypesNative(JNIEnv *env, jclass clazz) {
+    uintptr_t count = 0;
+    const char *const *types = c2pa_builder_supported_mime_types(&count);
+    if (types == NULL) {
+        return NULL;
+    }
+    jobjectArray result = cstring_array_to_jarray(env, types, count);
+    c2pa_free_string_array(types, count);
+    return result;
+}
+
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromArchive(JNIEnv *env, jclass clazz, jlong streamPtr) {
     if (streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -285,9 +285,19 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
             return builder
         }
 
+        /**
+         * Returns the MIME types the builder supports for signing.
+         *
+         * @return The supported MIME types (e.g. "image/jpeg"), or an empty list if none
+         */
+        @JvmStatic
+        fun supportedMimeTypes(): List<String> = supportedMimeTypesNative()?.toList() ?: emptyList()
+
         @JvmStatic private external fun nativeFromArchive(streamHandle: Long): Long
 
         @JvmStatic private external fun nativeFromContext(contextPtr: Long): Long
+
+        @JvmStatic private external fun supportedMimeTypesNative(): Array<String>?
     }
 
     /**

--- a/library/src/main/kotlin/org/contentauth/c2pa/Reader.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Reader.kt
@@ -158,7 +158,17 @@ class Reader internal constructor(private var ptr: Long) : Closeable {
                 if (handle == 0L) null else Reader(handle)
             }
 
+        /**
+         * Returns the MIME types the reader supports for parsing.
+         *
+         * @return The supported MIME types (e.g. "image/jpeg"), or an empty list if none
+         */
+        @JvmStatic
+        fun supportedMimeTypes(): List<String> = supportedMimeTypesNative()?.toList() ?: emptyList()
+
         @JvmStatic private external fun nativeFromContext(contextPtr: Long): Long
+
+        @JvmStatic private external fun supportedMimeTypesNative(): Array<String>?
 
         @JvmStatic private external fun fromStreamNative(format: String, streamHandle: Long): Long
 

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -185,6 +185,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderOperations())
     results.add(builderTests.testBuilderNoEmbed())
     results.add(builderTests.testBuilderRemoteUrl())
+    results.add(builderTests.testSupportedMimeTypes())
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
     results.add(builderTests.testBuilderFromArchive())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -172,6 +172,27 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testSupportedMimeTypes(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Supported MIME Types") {
+            val builderTypes = Builder.supportedMimeTypes()
+            val readerTypes = Reader.supportedMimeTypes()
+            val success = builderTypes.isNotEmpty() &&
+                readerTypes.isNotEmpty() &&
+                builderTypes.any { it.equals("image/jpeg", ignoreCase = true) } &&
+                readerTypes.any { it.equals("image/jpeg", ignoreCase = true) }
+            TestResult(
+                "Supported MIME Types",
+                success,
+                if (success) {
+                    "Builder: ${builderTypes.size} types, Reader: ${readerTypes.size} types"
+                } else {
+                    "Expected non-empty lists containing image/jpeg"
+                },
+                "Builder types: ${builderTypes.joinToString()}; Reader types: ${readerTypes.joinToString()}",
+            )
+        }
+    }
+
     suspend fun testBuilderAddResource(): TestResult = withContext(Dispatchers.IO) {
         runTest("Builder Add Resource") {
             val manifestJson = TEST_MANIFEST_JSON


### PR DESCRIPTION
Part of GP-252 (umbrella: expose remaining c2pa-rs FFI surface).

Adds `Builder.supportedMimeTypes()` and `Reader.supportedMimeTypes()` returning `List<String>`, wiring `c2pa_builder_supported_mime_types` / `c2pa_reader_supported_mime_types` (results released via `c2pa_free_string_array`). Includes a combined shared test.

Linear: https://linear.app/redaranj/issue/GP-258

Verification: compiles (Kotlin + JNI syntax-check); native .so build and instrumented tests pending on-device.