### PR TITLE
GP-257: Expose ingredient archive import/export

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -70,6 +70,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestBuilderIngredientArchive() = runBlocking {
+        val result = testBuilderIngredientArchive()
+        assertTrue(result.success, "Builder Ingredient Archive test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderFromArchive() = runBlocking {
         val result = testBuilderFromArchive()
         assertTrue(result.success, "Builder from Archive test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -858,6 +858,38 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_toArchiveNative(JNIEnv 
     return c2pa_builder_to_archive(builder, stream);
 }
 
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
+    if (builderPtr == 0 || streamPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and stream cannot be null");
+        return -1;
+    }
+
+    struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
+    struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
+    return c2pa_builder_add_ingredient_from_archive(builder, stream);
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_writeIngredientArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientId, jlong streamPtr) {
+    if (builderPtr == 0 || ingredientId == NULL || streamPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder, ingredient id, and stream cannot be null");
+        return -1;
+    }
+
+    const char *cingredientId = jstring_to_cstring(env, ingredientId);
+    if (cingredientId == NULL) {
+        return -1;
+    }
+
+    struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
+    int result = c2pa_builder_write_ingredient_archive(
+        (struct C2paBuilder*)(uintptr_t)builderPtr, cingredientId, stream
+    );
+    release_cstring(env, ingredientId, cingredientId);
+    return result;
+}
+
 JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr, jlong signerPtr) {
     if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0 || signerPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -456,6 +456,27 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
     }
 
     /**
+     * Imports an ingredient into this builder from a single-ingredient C2PA archive stream.
+     *
+     * The archive is one previously produced by [writeIngredientArchive]. Rewind the stream to
+     * its start before calling.
+     *
+     * @param archive The input stream containing the single-ingredient archive
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the ingredient cannot be imported
+     *
+     * @see writeIngredientArchive
+     */
+    @Throws(C2PAError::class)
+    fun addIngredientFromArchive(archive: Stream): Builder {
+        val result = addIngredientFromArchiveNative(ptr, archive.rawPtr)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to add ingredient from archive")
+        }
+        return this
+    }
+
+    /**
      * Writes the builder state to an archive stream.
      *
      * Archives are portable representations of a manifest and its associated resources
@@ -469,6 +490,27 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         val result = toArchiveNative(ptr, dest.rawPtr)
         if (result < 0) {
             throw C2PAError.Api(C2PA.getError() ?: "Failed to write archive")
+        }
+    }
+
+    /**
+     * Writes a single-ingredient C2PA archive for the given ingredient to the destination stream.
+     *
+     * The archive can later be imported into another builder with [addIngredientFromArchive].
+     * This requires the `generate_c2pa_archive` builder setting to be enabled in the settings used
+     * to create this builder.
+     *
+     * @param ingredientId Identifier of the ingredient within this builder to serialize
+     * @param dest The output stream to write the ingredient archive to
+     * @throws C2PAError.Api if the ingredient archive cannot be written
+     *
+     * @see addIngredientFromArchive
+     */
+    @Throws(C2PAError::class)
+    fun writeIngredientArchive(ingredientId: String, dest: Stream) {
+        val result = writeIngredientArchiveNative(ptr, ingredientId, dest.rawPtr)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to write ingredient archive")
         }
     }
 
@@ -572,6 +614,8 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         sourceHandle: Long,
     ): Int
     private external fun toArchiveNative(handle: Long, streamHandle: Long): Int
+    private external fun addIngredientFromArchiveNative(handle: Long, streamHandle: Long): Int
+    private external fun writeIngredientArchiveNative(handle: Long, ingredientId: String, streamHandle: Long): Int
     private external fun signNative(
         handle: Long,
         format: String,

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -187,6 +187,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderRemoteUrl())
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
+    results.add(builderTests.testBuilderIngredientArchive())
     results.add(builderTests.testBuilderFromArchive())
     results.add(builderTests.testReaderWithManifestData())
     results.add(builderTests.testJsonRoundTrip())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -284,6 +284,75 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testBuilderIngredientArchive(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Builder Ingredient Archive") {
+            val ingredientId = "archive-ingredient-1"
+            val ingredientJson =
+                """{"title": "Archive Ingredient", "format": "image/jpeg", "instance_id": "$ingredientId"}"""
+            // generate_c2pa_archive must be enabled for writeIngredientArchive to succeed.
+            val settingsJson =
+                """
+                {
+                    "version": 1,
+                    "builder": {
+                        "generate_c2pa_archive": true,
+                        "created_assertion_labels": ["c2pa.actions", "c2pa.ingredient.v3"]
+                    }
+                }
+                """.trimIndent()
+
+            try {
+                // Export: build an ingredient archive from one builder.
+                val settings = C2PASettings.create().apply { updateFromString(settingsJson, "json") }
+                val archiveData =
+                    try {
+                        C2PAContext.fromSettings(settings).use { context ->
+                            Builder.fromContext(context).withDefinition(TEST_MANIFEST_JSON).use { ingredientBuilder ->
+                                val ingredientImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                                ByteArrayStream(ingredientImageData).use { ingredientStream ->
+                                    ingredientBuilder.addIngredient(ingredientJson, "image/jpeg", ingredientStream)
+                                }
+                                ByteArrayStream().use { archiveStream ->
+                                    ingredientBuilder.writeIngredientArchive(ingredientId, archiveStream)
+                                    archiveStream.getData()
+                                }
+                            }
+                        }
+                    } finally {
+                        settings.close()
+                    }
+
+                // Import: load that archive into a parent builder.
+                var imported = false
+                Builder.fromJson(TEST_MANIFEST_JSON).use { parentBuilder ->
+                    ByteArrayStream(archiveData).use { archiveStream ->
+                        parentBuilder.addIngredientFromArchive(archiveStream)
+                        imported = true
+                    }
+                }
+
+                val success = archiveData.isNotEmpty() && imported
+                TestResult(
+                    "Builder Ingredient Archive",
+                    success,
+                    if (success) {
+                        "Ingredient archive round-trip succeeded"
+                    } else {
+                        "Ingredient archive round-trip failed"
+                    },
+                    "Archive size: ${archiveData.size} bytes, Imported: $imported",
+                )
+            } catch (e: C2PAError) {
+                TestResult(
+                    "Builder Ingredient Archive",
+                    false,
+                    "Ingredient archive round-trip threw",
+                    e.toString(),
+                )
+            }
+        }
+    }
+
     suspend fun testBuilderFromArchive(): TestResult = withContext(Dispatchers.IO) {
         runTest("Builder from Archive") {
             val manifestJson = TEST_MANIFEST_JSON


### PR DESCRIPTION
Part of GP-252 (umbrella: expose remaining c2pa-rs FFI surface).

Adds `Builder.addIngredientFromArchive()` and `Builder.writeIngredientArchive()`, wiring `c2pa_builder_add_ingredient_from_archive` and `c2pa_builder_write_ingredient_archive` through the JNI bridge for round-tripping ingredients via single-ingredient archives. Includes a shared round-trip test.

Linear: https://linear.app/redaranj/issue/GP-257

Verification: compiles (Kotlin + JNI syntax-check); native .so build and instrumented tests pending on-device. The ingredient_id<->instance_id mapping in the test needs on-device confirmation.