### PR TITLE
GP-255: Complete embeddable and data-hash signing

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -70,6 +70,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestEmbeddableAndPlaceholder() = runBlocking {
+        val result = testEmbeddableAndPlaceholder()
+        assertTrue(result.success, "Embeddable and Placeholder test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderFromArchive() = runBlocking {
         val result = testBuilderFromArchive()
         assertTrue(result.success, "Builder from Archive test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -992,7 +992,169 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmb
     jbyteArray result = (*env)->NewByteArray(env, size);
     (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
     c2pa_free(manifestBytes);
-    
+
+    return result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
+    if (builderPtr == 0 || format == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and format cannot be null");
+        return NULL;
+    }
+
+    struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return NULL;
+    }
+
+    const unsigned char *manifestBytes = NULL;
+    int64_t size = c2pa_builder_sign_embeddable(builder, cformat, &manifestBytes);
+    release_cstring(env, format, cformat);
+
+    if (size < 0 || manifestBytes == NULL) {
+        return NULL;
+    }
+
+    jbyteArray result = safe_new_byte_array(env, size);
+    if (result == NULL) {
+        c2pa_free(manifestBytes);
+        return NULL;
+    }
+    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
+    if (check_exception(env)) {
+        c2pa_free(manifestBytes);
+        return NULL;
+    }
+    c2pa_free(manifestBytes);
+    return result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_placeholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
+    if (builderPtr == 0 || format == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and format cannot be null");
+        return NULL;
+    }
+
+    struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return NULL;
+    }
+
+    const unsigned char *manifestBytes = NULL;
+    int64_t size = c2pa_builder_placeholder(builder, cformat, &manifestBytes);
+    release_cstring(env, format, cformat);
+
+    if (size < 0 || manifestBytes == NULL) {
+        return NULL;
+    }
+
+    jbyteArray result = safe_new_byte_array(env, size);
+    if (result == NULL) {
+        c2pa_free(manifestBytes);
+        return NULL;
+    }
+    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
+    if (check_exception(env)) {
+        c2pa_free(manifestBytes);
+        return NULL;
+    }
+    c2pa_free(manifestBytes);
+    return result;
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_needsPlaceholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
+    if (builderPtr == 0 || format == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and format cannot be null");
+        return -1;
+    }
+
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return -1;
+    }
+
+    int result = c2pa_builder_needs_placeholder((struct C2paBuilder*)(uintptr_t)builderPtr, cformat);
+    release_cstring(env, format, cformat);
+    return result;
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setDataHashExclusionsNative(JNIEnv *env, jobject obj, jlong builderPtr, jlongArray exclusions) {
+    if (builderPtr == 0 || exclusions == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and exclusions cannot be null");
+        return -1;
+    }
+
+    jsize len = (*env)->GetArrayLength(env, exclusions);
+    if (len % 2 != 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Exclusions must be a flat array of (start, length) pairs");
+        return -1;
+    }
+
+    jlong *elems = (*env)->GetLongArrayElements(env, exclusions, NULL);
+    if (elems == NULL) {
+        check_exception(env);
+        return -1;
+    }
+
+    // jlong and uint64_t are both 64-bit; the bit patterns are identical.
+    int result = c2pa_builder_set_data_hash_exclusions(
+        (struct C2paBuilder*)(uintptr_t)builderPtr,
+        (const uint64_t*)elems,
+        (uintptr_t)(len / 2)
+    );
+
+    (*env)->ReleaseLongArrayElements(env, exclusions, elems, JNI_ABORT);
+    return result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_formatEmbeddableNative(JNIEnv *env, jclass clazz, jstring format, jbyteArray manifestData) {
+    if (format == NULL || manifestData == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Format and manifest data cannot be null");
+        return NULL;
+    }
+
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return NULL;
+    }
+
+    jsize dataSize = (*env)->GetArrayLength(env, manifestData);
+    jbyte *data = (*env)->GetByteArrayElements(env, manifestData, NULL);
+    if (data == NULL) {
+        release_cstring(env, format, cformat);
+        check_exception(env);
+        return NULL;
+    }
+
+    const unsigned char *resultBytes = NULL;
+    int64_t size = c2pa_format_embeddable(cformat, (const unsigned char*)data, (uintptr_t)dataSize, &resultBytes);
+
+    (*env)->ReleaseByteArrayElements(env, manifestData, data, JNI_ABORT);
+    release_cstring(env, format, cformat);
+
+    if (size < 0 || resultBytes == NULL) {
+        return NULL;
+    }
+
+    jbyteArray result = safe_new_byte_array(env, size);
+    if (result == NULL) {
+        c2pa_free(resultBytes);
+        return NULL;
+    }
+    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)resultBytes);
+    if (check_exception(env)) {
+        c2pa_free(resultBytes);
+        return NULL;
+    }
+    c2pa_free(resultBytes);
     return result;
 }
 

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -285,9 +285,28 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
             return builder
         }
 
+        /**
+         * Wraps raw manifest bytes into a format-specific embeddable block.
+         *
+         * Use this to convert the bytes produced by [signDataHashedEmbeddable] or
+         * [signEmbeddable] into a block ready to embed in an asset of the given format.
+         *
+         * @param format The MIME type of the target asset (e.g. "image/jpeg")
+         * @param manifestBytes The raw manifest bytes to wrap
+         * @return The embeddable manifest bytes for the given format
+         * @throws C2PAError.Api if the bytes cannot be formatted
+         */
+        @JvmStatic
+        @Throws(C2PAError::class)
+        fun formatEmbeddable(format: String, manifestBytes: ByteArray): ByteArray =
+            formatEmbeddableNative(format, manifestBytes)
+                ?: throw C2PAError.Api(C2PA.getError() ?: "Failed to format embeddable manifest")
+
         @JvmStatic private external fun nativeFromArchive(streamHandle: Long): Long
 
         @JvmStatic private external fun nativeFromContext(contextPtr: Long): Long
+
+        @JvmStatic private external fun formatEmbeddableNative(format: String, manifestData: ByteArray): ByteArray?
     }
 
     /**
@@ -550,6 +569,76 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         return result
     }
 
+    /**
+     * Signs the manifest and returns embeddable manifest bytes for caller-managed embedding.
+     *
+     * Unlike [sign], this does not write a signed asset; it returns the manifest bytes so the
+     * caller controls how/where they are embedded. Requires a valid hard-binding assertion.
+     *
+     * @param format The MIME type of the target asset (e.g. "image/jpeg")
+     * @return The signed, embeddable manifest bytes
+     * @throws C2PAError.Api if signing fails
+     */
+    @Throws(C2PAError::class)
+    fun signEmbeddable(format: String): ByteArray =
+        signEmbeddableNative(ptr, format)
+            ?: throw C2PAError.Api(C2PA.getError() ?: "Failed to sign embeddable")
+
+    /**
+     * Returns the composed placeholder manifest bytes for the given format.
+     *
+     * The placeholder reserves space in the asset for a manifest that will be signed later in a
+     * deferred (data-hashed) signing workflow.
+     *
+     * @param format The MIME type of the target asset (e.g. "image/jpeg")
+     * @return The composed placeholder bytes
+     * @throws C2PAError.Api if the placeholder cannot be created
+     */
+    @Throws(C2PAError::class)
+    fun placeholder(format: String): ByteArray =
+        placeholderNative(ptr, format)
+            ?: throw C2PAError.Api(C2PA.getError() ?: "Failed to create placeholder")
+
+    /**
+     * Returns whether a placeholder manifest is required for the given format.
+     *
+     * @param format The MIME type of the target asset (e.g. "image/jpeg")
+     * @return `true` if a placeholder is required, `false` otherwise
+     * @throws C2PAError.Api if the requirement cannot be determined
+     */
+    @Throws(C2PAError::class)
+    fun needsPlaceholder(format: String): Boolean {
+        val result = needsPlaceholderNative(ptr, format)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to determine placeholder requirement")
+        }
+        return result == 1
+    }
+
+    /**
+     * Sets the byte exclusion ranges on the builder's DataHash assertion.
+     *
+     * Each pair is `(start, length)` in bytes. Requires [placeholder] to have been called first so
+     * a DataHash assertion exists.
+     *
+     * @param exclusions The byte ranges to exclude from the data hash, as `(start, length)` pairs
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the exclusions cannot be set
+     */
+    @Throws(C2PAError::class)
+    fun setDataHashExclusions(exclusions: List<Pair<Long, Long>>): Builder {
+        val flat = LongArray(exclusions.size * 2)
+        exclusions.forEachIndexed { i, (start, length) ->
+            flat[i * 2] = start
+            flat[i * 2 + 1] = length
+        }
+        val result = setDataHashExclusionsNative(ptr, flat)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to set data hash exclusions")
+        }
+        return this
+    }
+
     override fun close() {
         if (ptr != 0L) {
             free(ptr)
@@ -587,4 +676,8 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         format: String,
         assetHandle: Long,
     ): ByteArray?
+    private external fun signEmbeddableNative(handle: Long, format: String): ByteArray?
+    private external fun placeholderNative(handle: Long, format: String): ByteArray?
+    private external fun needsPlaceholderNative(handle: Long, format: String): Int
+    private external fun setDataHashExclusionsNative(handle: Long, exclusions: LongArray): Int
 }

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -187,6 +187,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderRemoteUrl())
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
+    results.add(builderTests.testEmbeddableAndPlaceholder())
     results.add(builderTests.testBuilderFromArchive())
     results.add(builderTests.testReaderWithManifestData())
     results.add(builderTests.testJsonRoundTrip())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -284,6 +284,58 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testEmbeddableAndPlaceholder(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Embeddable and Placeholder") {
+            try {
+                // Placeholder composition + needsPlaceholder + setDataHashExclusions.
+                // placeholder() creates the DataHash assertion that exclusions then attach to.
+                val placeholderBytes = Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                    builder.needsPlaceholder("image/jpeg")
+                    val placeholder = builder.placeholder("image/jpeg")
+                    builder.setDataHashExclusions(listOf(0L to 2L))
+                    placeholder
+                }
+
+                // formatEmbeddable over manifest bytes produced by a no-embed sign.
+                val certPem = loadResourceAsString("es256_certs")
+                val keyPem = loadResourceAsString("es256_private")
+                val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                val formattedSize = Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                    builder.setNoEmbed()
+                    ByteArrayStream(sourceImageData).use { source ->
+                        ByteArrayStream().use { dest ->
+                            Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                val signResult = builder.sign("image/jpeg", source, dest, signer)
+                                val manifestBytes = signResult.manifestBytes
+                                    ?: throw C2PAError.Api("No manifest bytes from no-embed sign")
+                                Builder.formatEmbeddable("image/jpeg", manifestBytes).size
+                            }
+                        }
+                    }
+                }
+
+                val success = placeholderBytes.isNotEmpty() && formattedSize > 0
+                TestResult(
+                    "Embeddable and Placeholder",
+                    success,
+                    if (success) {
+                        "Placeholder, exclusions, and formatEmbeddable succeeded"
+                    } else {
+                        "Embeddable flow produced empty output"
+                    },
+                    "Placeholder bytes: ${placeholderBytes.size}, Formatted size: $formattedSize",
+                )
+            } catch (e: C2PAError) {
+                TestResult(
+                    "Embeddable and Placeholder",
+                    false,
+                    "Embeddable flow threw",
+                    e.toString(),
+                )
+            }
+        }
+    }
+
     suspend fun testBuilderFromArchive(): TestResult = withContext(Dispatchers.IO) {
         runTest("Builder from Archive") {
             val manifestJson = TEST_MANIFEST_JSON


### PR DESCRIPTION
Part of GP-252 (umbrella: expose remaining c2pa-rs FFI surface).

Adds `signEmbeddable`, `placeholder`, `needsPlaceholder`, `setDataHashExclusions`, and static `formatEmbeddable` to `Builder`, wiring the remaining embeddable/data-hash FFI functions. Includes a shared test for placeholder/exclusions/formatEmbeddable.

Linear: https://linear.app/redaranj/issue/GP-255

Verification: compiles (Kotlin + JNI syntax-check). `signEmbeddable` needs a context-attached signer (GP-254) to exercise; pending on-device.