### PR TITLE
GP-256: Expose BMFF fragmented media Merkle hashing

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -70,6 +70,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestBuilderHashType() = runBlocking {
+        val result = testBuilderHashType()
+        assertTrue(result.success, "Builder Hash Type test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderFromArchive() = runBlocking {
         val result = testBuilderFromArchive()
         assertTrue(result.success, "Builder from Archive test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -992,8 +992,87 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmb
     jbyteArray result = (*env)->NewByteArray(env, size);
     (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
     c2pa_free(manifestBytes);
-    
+
     return result;
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setFixedSizeMerkleNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong fixedSizeKb) {
+    if (builderPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder cannot be null");
+        return -1;
+    }
+    return c2pa_builder_set_fixed_size_merkle((struct C2paBuilder*)(uintptr_t)builderPtr, (uintptr_t)fixedSizeKb);
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashMdatBytesNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong mdatId, jbyteArray data, jboolean largeSize) {
+    if (builderPtr == 0 || data == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and data cannot be null");
+        return -1;
+    }
+
+    jsize dataLen = (*env)->GetArrayLength(env, data);
+    jbyte *dataPtr = (*env)->GetByteArrayElements(env, data, NULL);
+    if (dataPtr == NULL) {
+        check_exception(env);
+        return -1;
+    }
+
+    int result = c2pa_builder_hash_mdat_bytes(
+        (struct C2paBuilder*)(uintptr_t)builderPtr,
+        (uintptr_t)mdatId,
+        (const unsigned char*)dataPtr,
+        (uintptr_t)dataLen,
+        largeSize == JNI_TRUE
+    );
+
+    (*env)->ReleaseByteArrayElements(env, data, dataPtr, JNI_ABORT);
+    return result;
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_updateHashFromStreamNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong streamPtr) {
+    if (builderPtr == 0 || format == NULL || streamPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder, format, and stream cannot be null");
+        return -1;
+    }
+
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return -1;
+    }
+
+    int result = c2pa_builder_update_hash_from_stream(
+        (struct C2paBuilder*)(uintptr_t)builderPtr,
+        cformat,
+        (struct C2paStream*)(uintptr_t)streamPtr
+    );
+
+    release_cstring(env, format, cformat);
+    return result;
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashTypeNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
+    if (builderPtr == 0 || format == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and format cannot be null");
+        return -1;
+    }
+
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return -1;
+    }
+
+    enum C2paHashType hashType;
+    int result = c2pa_builder_hash_type((struct C2paBuilder*)(uintptr_t)builderPtr, cformat, &hashType);
+    release_cstring(env, format, cformat);
+
+    if (result < 0) {
+        return -1;
+    }
+    return (jint)hashType;
 }
 
 // Signer native methods

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -550,6 +550,81 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         return result
     }
 
+    /**
+     * Enables fixed-size Merkle-tree hashing for fragmented (BMFF) assets.
+     *
+     * Produces a Merkle tree per `mdat` with fixed-size leaves, for efficient hashing of large
+     * assets. Requires that a placeholder has been created on the builder first.
+     *
+     * @param fixedSizeKb Fixed leaf block size, in KB
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the setting cannot be applied
+     */
+    @Throws(C2PAError::class)
+    fun setFixedSizeMerkle(fixedSizeKb: Long): Builder {
+        val result = setFixedSizeMerkleNative(ptr, fixedSizeKb)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to set fixed size merkle")
+        }
+        return this
+    }
+
+    /**
+     * Generates `mdat` leaf hashes for a chunk of fragmented-media data.
+     *
+     * Supply chunks in the order they are written to the `mdat`. `mdatId` starts at 0 and
+     * increments for each `mdat` in the asset.
+     *
+     * @param mdatId The mdat index (0-based)
+     * @param data The mdat chunk bytes
+     * @param largeSize Whether the mdat uses 64-bit (large) box sizing
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if hashing fails
+     */
+    @Throws(C2PAError::class)
+    fun hashMdatBytes(mdatId: Long, data: ByteArray, largeSize: Boolean): Builder {
+        val result = hashMdatBytesNative(ptr, mdatId, data, largeSize)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to hash mdat bytes")
+        }
+        return this
+    }
+
+    /**
+     * Updates the builder's hash by reading the asset from a stream.
+     *
+     * For DataHash workflows, register data-hash exclusions before calling this.
+     *
+     * @param format The MIME type of the asset (e.g. "video/mp4")
+     * @param stream The asset stream to hash
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if hashing fails
+     */
+    @Throws(C2PAError::class)
+    fun updateHashFromStream(format: String, stream: Stream): Builder {
+        val result = updateHashFromStreamNative(ptr, format, stream.rawPtr)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to update hash from stream")
+        }
+        return this
+    }
+
+    /**
+     * Returns the hash binding type the builder will use for the given format.
+     *
+     * @param format The MIME type of the asset (e.g. "image/jpeg", "video/mp4")
+     * @return The [HashType] for the format
+     * @throws C2PAError.Api if the type cannot be determined
+     */
+    @Throws(C2PAError::class)
+    fun hashType(format: String): HashType {
+        val result = hashTypeNative(ptr, format)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to determine hash type")
+        }
+        return HashType.fromValue(result)
+    }
+
     override fun close() {
         if (ptr != 0L) {
             free(ptr)
@@ -587,4 +662,8 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         format: String,
         assetHandle: Long,
     ): ByteArray?
+    private external fun setFixedSizeMerkleNative(handle: Long, fixedSizeKb: Long): Int
+    private external fun hashMdatBytesNative(handle: Long, mdatId: Long, data: ByteArray, largeSize: Boolean): Int
+    private external fun updateHashFromStreamNative(handle: Long, format: String, streamHandle: Long): Int
+    private external fun hashTypeNative(handle: Long, format: String): Int
 }

--- a/library/src/main/kotlin/org/contentauth/c2pa/HashType.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/HashType.kt
@@ -1,0 +1,41 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa
+
+/**
+ * Hash binding type a [Builder] uses for a given asset format.
+ *
+ * Mirrors the native `C2paHashType` enum.
+ */
+enum class HashType(val value: Int) {
+    /** Placeholder + exclusions + hash + sign (JPEG, PNG, etc.). */
+    DATA_HASH(0),
+
+    /** Placeholder + hash + sign (MP4, AVIF, HEIF/HEIC). */
+    BMFF_HASH(1),
+
+    /** Hash + sign, no placeholder needed. */
+    BOX_HASH(2),
+    ;
+
+    companion object {
+        /**
+         * Returns the [HashType] for the given native enum value.
+         *
+         * @throws IllegalArgumentException if the value does not correspond to a known type
+         */
+        fun fromValue(value: Int): HashType =
+            entries.firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException("Unknown hash type value: $value")
+    }
+}

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -187,6 +187,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderRemoteUrl())
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
+    results.add(builderTests.testBuilderHashType())
     results.add(builderTests.testBuilderFromArchive())
     results.add(builderTests.testReaderWithManifestData())
     results.add(builderTests.testJsonRoundTrip())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -25,6 +25,7 @@ import org.contentauth.c2pa.C2PAContext
 import org.contentauth.c2pa.C2PASettings
 import org.contentauth.c2pa.DigitalSourceType
 import org.contentauth.c2pa.FileStream
+import org.contentauth.c2pa.HashType
 import org.contentauth.c2pa.PredefinedAction
 import org.contentauth.c2pa.Reader
 import org.contentauth.c2pa.Signer
@@ -278,6 +279,35 @@ abstract class BuilderTests : TestBase() {
                     "Builder Add Ingredient",
                     false,
                     "Failed to create builder",
+                    e.toString(),
+                )
+            }
+        }
+    }
+
+    suspend fun testBuilderHashType(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Builder Hash Type") {
+            try {
+                Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                    val jpegType = builder.hashType("image/jpeg")
+                    val mp4Type = builder.hashType("video/mp4")
+                    val success = jpegType == HashType.DATA_HASH && mp4Type == HashType.BMFF_HASH
+                    TestResult(
+                        "Builder Hash Type",
+                        success,
+                        if (success) {
+                            "Hash types resolved correctly"
+                        } else {
+                            "Unexpected hash types"
+                        },
+                        "image/jpeg -> $jpegType, video/mp4 -> $mp4Type",
+                    )
+                }
+            } catch (e: C2PAError) {
+                TestResult(
+                    "Builder Hash Type",
+                    false,
+                    "hashType threw",
                     e.toString(),
                 )
             }


### PR DESCRIPTION
Part of GP-252 (umbrella: expose remaining c2pa-rs FFI surface).

Adds `setFixedSizeMerkle`, `hashMdatBytes`, `updateHashFromStream`, and `hashType` to `Builder`, plus a `HashType` enum mirroring native `C2paHashType`. Wires the BMFF hashing FFI functions. Includes a shared `hashType` test.

Linear: https://linear.app/redaranj/issue/GP-256

Verification: compiles (Kotlin + JNI syntax-check). The merkle/mdat/stream-hash flow needs an MP4 fixture to validate on-device.