### PR TITLE
GP-254: Expose context signer and cancellation

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -70,6 +70,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestContextBuilderWithSigner() = runBlocking {
+        val result = testContextBuilderWithSigner()
+        assertTrue(result.success, "Context Builder with Signer test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderFromArchive() = runBlocking {
         val result = testBuilderFromArchive()
         assertTrue(result.success, "Builder from Archive test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -1295,6 +1295,61 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_C2PAContext_free(JNIEnv *env, j
     }
 }
 
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContext_cancelNative(JNIEnv *env, jobject obj, jlong contextPtr) {
+    if (contextPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Context cannot be null");
+        return -1;
+    }
+    return c2pa_context_cancel((struct C2paContext*)(uintptr_t)contextPtr);
+}
+
+// Context builder methods
+JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_nativeNew(JNIEnv *env, jclass clazz) {
+    struct C2paContextBuilder *builder = c2pa_context_builder_new();
+    return (jlong)(uintptr_t)builder;
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSettingsNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong settingsPtr) {
+    if (builderPtr == 0 || settingsPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and settings cannot be null");
+        return -1;
+    }
+    return c2pa_context_builder_set_settings(
+        (struct C2paContextBuilder*)(uintptr_t)builderPtr,
+        (struct C2paSettings*)(uintptr_t)settingsPtr
+    );
+}
+
+JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSignerNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong signerPtr) {
+    if (builderPtr == 0 || signerPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and signer cannot be null");
+        return -1;
+    }
+    // The FFI consumes the signer; the Kotlin wrapper zeros its pointer on success.
+    return c2pa_context_builder_set_signer(
+        (struct C2paContextBuilder*)(uintptr_t)builderPtr,
+        (struct C2paSigner*)(uintptr_t)signerPtr
+    );
+}
+
+JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_buildNative(JNIEnv *env, jobject obj, jlong builderPtr) {
+    if (builderPtr == 0) {
+        return 0;
+    }
+    // build consumes the builder regardless of outcome.
+    struct C2paContext *context = c2pa_context_builder_build((struct C2paContextBuilder*)(uintptr_t)builderPtr);
+    return (jlong)(uintptr_t)context;
+}
+
+JNIEXPORT void JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_free(JNIEnv *env, jobject obj, jlong builderPtr) {
+    if (builderPtr != 0) {
+        c2pa_free((const void*)(uintptr_t)builderPtr);
+    }
+}
+
 // Builder context-based methods
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromContext(JNIEnv *env, jclass clazz, jlong contextPtr) {
     if (contextPtr == 0) {

--- a/library/src/main/kotlin/org/contentauth/c2pa/C2PAContext.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/C2PAContext.kt
@@ -94,6 +94,22 @@ class C2PAContext internal constructor(internal var ptr: Long) : Closeable {
         @JvmStatic private external fun nativeNewWithSettings(settingsPtr: Long): Long
     }
 
+    /**
+     * Requests cancellation of an in-flight operation running on this context.
+     *
+     * Intended to be called from another thread while a [Reader] or [Builder] operation created
+     * from this context is in progress; the SDK returns an error at the next safe stopping point.
+     *
+     * @throws C2PAError.Api if the cancellation request fails
+     */
+    @Throws(C2PAError::class)
+    fun cancel() {
+        val result = cancelNative(ptr)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to cancel context operation")
+        }
+    }
+
     override fun close() {
         if (ptr != 0L) {
             free(ptr)
@@ -102,4 +118,5 @@ class C2PAContext internal constructor(internal var ptr: Long) : Closeable {
     }
 
     private external fun free(handle: Long)
+    private external fun cancelNative(handle: Long): Int
 }

--- a/library/src/main/kotlin/org/contentauth/c2pa/C2PAContextBuilder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/C2PAContextBuilder.kt
@@ -1,0 +1,145 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa
+
+import java.io.Closeable
+
+/**
+ * Mutable builder for assembling a configured [C2PAContext].
+ *
+ * Use this when a context needs more than default or settings-only configuration — for example to
+ * attach a programmatic signer that [Reader] and [Builder] instances created from the context will
+ * use. Configure the builder fluently, then call [build] to produce an immutable, shareable
+ * [C2PAContext].
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val context = C2PAContextBuilder.create()
+ *     .setSettings(settings)
+ *     .setSigner(signer)
+ *     .build()
+ * ```
+ *
+ * ## Resource Management
+ *
+ * The builder implements [Closeable]. [build] consumes the builder, so an explicit [close] is only
+ * needed when the builder is abandoned without building (use a `use { }` block to be safe).
+ *
+ * @property ptr Internal pointer to the native C2paContextBuilder instance
+ * @see C2PAContext
+ * @see C2PASettings
+ * @see Signer
+ */
+class C2PAContextBuilder internal constructor(private var ptr: Long) : Closeable {
+
+    companion object {
+        init {
+            loadC2PALibraries()
+        }
+
+        /**
+         * Creates a new, empty context builder.
+         *
+         * @return A new [C2PAContextBuilder]
+         * @throws C2PAError.Api if the builder cannot be created
+         */
+        @JvmStatic
+        @Throws(C2PAError::class)
+        fun create(): C2PAContextBuilder = executeC2PAOperation("Failed to create C2PAContextBuilder") {
+            val handle = nativeNew()
+            if (handle == 0L) null else C2PAContextBuilder(handle)
+        }
+
+        @JvmStatic private external fun nativeNew(): Long
+    }
+
+    /**
+     * Applies settings to the context being built.
+     *
+     * The settings are cloned internally, so the caller retains ownership of [settings].
+     *
+     * @param settings The settings to apply
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the settings cannot be applied
+     */
+    @Throws(C2PAError::class)
+    fun setSettings(settings: C2PASettings): C2PAContextBuilder {
+        val result = setSettingsNative(ptr, settings.ptr)
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to set context settings")
+        }
+        return this
+    }
+
+    /**
+     * Attaches a signer to the context being built.
+     *
+     * Ownership of [signer] transfers to the context: it is *consumed* by this call and must not be
+     * used or closed again. The wrapper zeros the signer's internal pointer on success, so calling
+     * `close()` on it (or wrapping it in a `use { }` block) is a safe no-op afterward. If a signer
+     * is also configured via settings, the programmatic signer set here takes priority.
+     *
+     * @param signer The signer to attach (consumed by this call)
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the signer is already consumed/closed or cannot be attached
+     */
+    @Throws(C2PAError::class)
+    fun setSigner(signer: Signer): C2PAContextBuilder {
+        if (signer.ptr == 0L) {
+            throw C2PAError.Api("signer is already closed or consumed")
+        }
+        val result = setSignerNative(ptr, signer.ptr)
+        // The FFI consumes the signer whether or not it succeeds; drop our reference either way.
+        signer.ptr = 0L
+        if (result < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to set context signer")
+        }
+        return this
+    }
+
+    /**
+     * Builds an immutable, shareable [C2PAContext] from this builder.
+     *
+     * The builder is *consumed* by this call and must not be used again; [close] afterward is a
+     * safe no-op.
+     *
+     * @return The built [C2PAContext]
+     * @throws C2PAError.Api if the context cannot be built
+     */
+    @Throws(C2PAError::class)
+    fun build(): C2PAContext {
+        if (ptr == 0L) {
+            throw C2PAError.Api("context builder is already consumed")
+        }
+        val handle = buildNative(ptr)
+        // build() consumes the builder regardless of outcome.
+        ptr = 0L
+        if (handle == 0L) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to build context")
+        }
+        return C2PAContext(handle)
+    }
+
+    override fun close() {
+        if (ptr != 0L) {
+            free(ptr)
+            ptr = 0
+        }
+    }
+
+    private external fun free(handle: Long)
+    private external fun setSettingsNative(handle: Long, settingsPtr: Long): Int
+    private external fun setSignerNative(handle: Long, signerPtr: Long): Int
+    private external fun buildNative(handle: Long): Long
+}

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -187,6 +187,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderRemoteUrl())
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
+    results.add(builderTests.testContextBuilderWithSigner())
     results.add(builderTests.testBuilderFromArchive())
     results.add(builderTests.testReaderWithManifestData())
     results.add(builderTests.testJsonRoundTrip())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -22,6 +22,7 @@ import org.contentauth.c2pa.ByteArrayStream
 import org.contentauth.c2pa.C2PA
 import org.contentauth.c2pa.C2PAError
 import org.contentauth.c2pa.C2PAContext
+import org.contentauth.c2pa.C2PAContextBuilder
 import org.contentauth.c2pa.C2PASettings
 import org.contentauth.c2pa.DigitalSourceType
 import org.contentauth.c2pa.FileStream
@@ -278,6 +279,60 @@ abstract class BuilderTests : TestBase() {
                     "Builder Add Ingredient",
                     false,
                     "Failed to create builder",
+                    e.toString(),
+                )
+            }
+        }
+    }
+
+    suspend fun testContextBuilderWithSigner(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Context Builder with Signer") {
+            try {
+                val certPem = loadResourceAsString("es256_certs")
+                val keyPem = loadResourceAsString("es256_private")
+                val settingsJson =
+                    """{"version": 1, "builder": {"created_assertion_labels": ["c2pa.actions"]}}"""
+
+                // Build a context with settings plus a programmatic signer attached.
+                val context = C2PASettings.create().use { settings ->
+                    settings.updateFromString(settingsJson, "json")
+                    val signer = Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem))
+                    C2PAContextBuilder.create()
+                        .setSettings(settings)
+                        .setSigner(signer) // consumes signer
+                        .build()
+                }
+
+                // The resulting context must be usable for creating a builder and signing.
+                val signedSize = context.use { ctx ->
+                    Builder.fromContext(ctx).withDefinition(TEST_MANIFEST_JSON).use { builder ->
+                        val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                        ByteArrayStream(sourceImageData).use { source ->
+                            ByteArrayStream().use { dest ->
+                                Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                    builder.sign("image/jpeg", source, dest, signer).size
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val success = signedSize > 0
+                TestResult(
+                    "Context Builder with Signer",
+                    success,
+                    if (success) {
+                        "Context built with signer produced a signed asset"
+                    } else {
+                        "Signing via the built context failed"
+                    },
+                    "Signed size: $signedSize",
+                )
+            } catch (e: C2PAError) {
+                TestResult(
+                    "Context Builder with Signer",
+                    false,
+                    "Context builder flow threw",
                     e.toString(),
                 )
             }


### PR DESCRIPTION
Part of GP-252 (umbrella: expose remaining c2pa-rs FFI surface).

Adds a `C2PAContextBuilder` Kotlin type (`setSettings`/`setSigner`/`build`) and `C2PAContext.cancel()`, wiring `c2pa_context_builder_new/set_settings/set_signer/build` and `c2pa_context_cancel`. Includes a shared context-builder-with-signer test.

The progress + HTTP-resolver callbacks were split into GP-263 (need device validation).

Linear: https://linear.app/redaranj/issue/GP-254

Verification: compiles (Kotlin + JNI syntax-check); native .so build and instrumented tests pending on-device.