### PR TITLE
GP-303: Migrate Reader.fromStream off deprecated FFI

### DIFF
--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -595,15 +595,28 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromStreamNative(JNIEnv
     }
     
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
-    struct C2paReader *reader = c2pa_reader_from_stream(cformat, stream);
-    
+
+    // Use the non-deprecated context-based path: create a reader from a default
+    // context, then attach the stream. The context can be released once the
+    // reader has been created from it.
+    struct C2paContext *ctx = c2pa_context_new();
+    struct C2paReader *reader = NULL;
+    if (ctx != NULL) {
+        struct C2paReader *base = c2pa_reader_from_context(ctx);
+        if (base != NULL) {
+            // with_stream consumes `base` and returns a new reader.
+            reader = c2pa_reader_with_stream(base, cformat, stream);
+        }
+        c2pa_free(ctx);
+    }
+
     release_cstring(env, format, cformat);
-    
+
     if (reader == NULL) {
         throw_c2pa_exception(env, "Failed to create reader from stream");
         return 0;
     }
-    
+
     return (jlong)(uintptr_t)reader;
 }
 


### PR DESCRIPTION
Part of GP-252 (umbrella). Deprecation-debt cleanup sibling of GP-261; closes part of the iOS-parity gap (GP-290).

Routes `Reader.fromStreamNative` through the non-deprecated context path (`c2pa_context_new` + `c2pa_reader_from_context` + `c2pa_reader_with_stream`), dropping the deprecated `c2pa_reader_from_stream`. Public `Reader.fromStream` signature unchanged.

**Scope decision:** `c2pa_load_settings` is intentionally retained — it is load-bearing for `Signer.fromSettings*`/`Signer.loadSettings` via `c2pa_signer_from_settings()` (reads global settings; no non-deprecated per-context alternative), survives 0.88.0, and iOS keeps it too. See the Linear issue.

Linear: https://linear.app/redaranj/issue/GP-303

Verification: JNI C passes `clang -fsyntax-only`; no `c2pa_reader_from_stream` references remain. Native `.so` build and instrumented tests pending on-device.