### PR TITLE
GP-263: Context progress + HTTP resolver callbacks

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -76,6 +76,18 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestContextProgressCallback() = runBlocking {
+        val result = testContextProgressCallback()
+        assertTrue(result.success, "Context Progress Callback test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestContextHttpResolver() = runBlocking {
+        val result = testContextHttpResolver()
+        assertTrue(result.success, "Context HTTP Resolver test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderFromArchive() = runBlocking {
         val result = testBuilderFromArchive()
         assertTrue(result.success, "Builder from Archive test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -43,6 +43,15 @@ typedef struct {
     jboolean isActive;     // Track if context is still valid
 } JavaSignerContext;
 
+// Context-builder callback context (progress observer / HTTP resolver).
+// Lifetime: created on the builder, ownership transferred to the built C2PAContext,
+// and freed when that context is closed. Mirrors the signer-callback pattern.
+typedef struct {
+    jobject callback;      // Global reference to the Kotlin bridge object
+    jmethodID method;      // Cached bridge method id
+    jboolean isActive;
+} JavaContextCallback;
+
 typedef struct SignerContextNode {
     JavaSignerContext *context;
     struct C2paSigner *signer;
@@ -408,6 +417,26 @@ static intptr_t java_signer_callback(const void *context, const unsigned char *d
     
     (*env)->DeleteLocalRef(env, jsignature);
     return sig_len;
+}
+
+// Progress callback trampoline. The Kotlin side is a Void observer, so this always
+// returns 1 (continue) — cancellation is exposed separately via C2PAContext.cancel(),
+// per the cross-platform API decision (GP-263).
+static int java_progress_callback(const void *context, enum C2paProgressPhase phase, uint32_t step, uint32_t total) {
+    JavaContextCallback *jctx = (JavaContextCallback*)context;
+    if (jctx == NULL || !jctx->isActive) {
+        return 1;
+    }
+
+    JNIEnv *env = get_jni_env();
+    if (env == NULL) {
+        return 1;
+    }
+
+    // Bridge signature: onProgress(int phase, long step, long total) -> void
+    (*env)->CallVoidMethod(env, jctx->callback, jctx->method, (jint)phase, (jlong)step, (jlong)total);
+    check_exception(env);
+    return 1;
 }
 
 // Native methods implementation
@@ -1304,6 +1333,20 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContext_cancelNative(JNIEnv
     return c2pa_context_cancel((struct C2paContext*)(uintptr_t)contextPtr);
 }
 
+// Frees a context callback (progress/HTTP-resolver) struct owned by a built context.
+// Called from C2PAContext.close() after the context itself has been freed.
+JNIEXPORT void JNICALL Java_org_contentauth_c2pa_C2PAContext_freeCallbackContextNative(JNIEnv *env, jclass clazz, jlong callbackPtr) {
+    if (callbackPtr == 0) {
+        return;
+    }
+    JavaContextCallback *jctx = (JavaContextCallback*)(uintptr_t)callbackPtr;
+    jctx->isActive = JNI_FALSE;
+    if (jctx->callback != NULL) {
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+    }
+    free(jctx);
+}
+
 // Context builder methods
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_nativeNew(JNIEnv *env, jclass clazz) {
     struct C2paContextBuilder *builder = c2pa_context_builder_new();
@@ -1333,6 +1376,55 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSignerNat
         (struct C2paContextBuilder*)(uintptr_t)builderPtr,
         (struct C2paSigner*)(uintptr_t)signerPtr
     );
+}
+
+JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgressCallbackNative(JNIEnv *env, jobject obj, jlong builderPtr, jobject bridge) {
+    if (builderPtr == 0 || bridge == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and progress callback cannot be null");
+        return 0;
+    }
+
+    JavaContextCallback *jctx = (JavaContextCallback*)calloc(1, sizeof(JavaContextCallback));
+    if (jctx == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
+                         "Failed to allocate progress callback context");
+        return 0;
+    }
+
+    jctx->callback = (*env)->NewGlobalRef(env, bridge);
+    if (jctx->callback == NULL) {
+        free(jctx);
+        check_exception(env);
+        return 0;
+    }
+
+    jclass bridgeClass = (*env)->GetObjectClass(env, bridge);
+    jctx->method = (*env)->GetMethodID(env, bridgeClass, "onProgress", "(IJJ)V");
+    (*env)->DeleteLocalRef(env, bridgeClass);
+    if (jctx->method == NULL) {
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+        free(jctx);
+        check_exception(env);
+        return 0;
+    }
+
+    jctx->isActive = JNI_TRUE;
+
+    int result = c2pa_context_builder_set_progress_callback(
+        (struct C2paContextBuilder*)(uintptr_t)builderPtr,
+        jctx,
+        java_progress_callback
+    );
+    if (result != 0) {
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+        free(jctx);
+        throw_c2pa_exception(env, "Failed to set progress callback");
+        return 0;
+    }
+
+    // Ownership of jctx transfers to the built context (freed in C2PAContext.close()).
+    return (jlong)(uintptr_t)jctx;
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_buildNative(JNIEnv *env, jobject obj, jlong builderPtr) {

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -439,6 +439,84 @@ static int java_progress_callback(const void *context, enum C2paProgressPhase ph
     return 1;
 }
 
+// HTTP resolver trampoline. Marshals the C request into the Kotlin bridge, reads back
+// status + body from the returned HttpResponse, and mallocs the body for Rust to free.
+// Returns 0 on success, -1 on error (with c2pa_error_set_last set).
+static int java_http_resolver_callback(void *context, const struct C2paHttpRequest *request,
+                                       struct C2paHttpResponse *response) {
+    JavaContextCallback *jctx = (JavaContextCallback*)context;
+    if (jctx == NULL || !jctx->isActive) {
+        c2pa_error_set_last("HTTP resolver is no longer active");
+        return -1;
+    }
+
+    JNIEnv *env = get_jni_env();
+    if (env == NULL) {
+        c2pa_error_set_last("Failed to attach JNI environment for HTTP resolver");
+        return -1;
+    }
+
+    jstring jurl = (request->url != NULL) ? cstring_to_jstring(env, request->url) : NULL;
+    jstring jmethod = (request->method != NULL) ? cstring_to_jstring(env, request->method) : NULL;
+    jstring jheaders = (request->headers != NULL) ? cstring_to_jstring(env, request->headers) : NULL;
+    jbyteArray jbody = NULL;
+    if (request->body != NULL && request->body_len > 0 && request->body_len <= INT32_MAX) {
+        jbody = safe_new_byte_array(env, (jsize)request->body_len);
+        if (jbody != NULL) {
+            (*env)->SetByteArrayRegion(env, jbody, 0, (jsize)request->body_len, (const jbyte*)request->body);
+        }
+    }
+
+    // Bridge: resolve(String url, String method, String headers, byte[] body) -> HttpResponse
+    jobject jresp = (*env)->CallObjectMethod(env, jctx->callback, jctx->method, jurl, jmethod, jheaders, jbody);
+    if (jurl != NULL) (*env)->DeleteLocalRef(env, jurl);
+    if (jmethod != NULL) (*env)->DeleteLocalRef(env, jmethod);
+    if (jheaders != NULL) (*env)->DeleteLocalRef(env, jheaders);
+    if (jbody != NULL) (*env)->DeleteLocalRef(env, jbody);
+
+    if (check_exception(env) || jresp == NULL) {
+        c2pa_error_set_last("HTTP resolver callback failed");
+        return -1;
+    }
+
+    jclass respClass = (*env)->GetObjectClass(env, jresp);
+    jmethodID getStatus = (*env)->GetMethodID(env, respClass, "getStatus", "()I");
+    jmethodID getBody = (*env)->GetMethodID(env, respClass, "getBody", "()[B");
+    (*env)->DeleteLocalRef(env, respClass);
+    if (getStatus == NULL || getBody == NULL) {
+        (*env)->DeleteLocalRef(env, jresp);
+        check_exception(env);
+        c2pa_error_set_last("Invalid HttpResponse from resolver");
+        return -1;
+    }
+
+    jint status = (*env)->CallIntMethod(env, jresp, getStatus);
+    jbyteArray respBody = (jbyteArray)(*env)->CallObjectMethod(env, jresp, getBody);
+    (*env)->DeleteLocalRef(env, jresp);
+
+    response->status = (int32_t)status;
+    response->body = NULL;
+    response->body_len = 0;
+
+    if (respBody != NULL) {
+        jsize blen = (*env)->GetArrayLength(env, respBody);
+        if (blen > 0) {
+            unsigned char *buf = (unsigned char*)malloc((size_t)blen);
+            if (buf == NULL) {
+                (*env)->DeleteLocalRef(env, respBody);
+                c2pa_error_set_last("Out of memory copying HTTP response body");
+                return -1;
+            }
+            (*env)->GetByteArrayRegion(env, respBody, 0, blen, (jbyte*)buf);
+            response->body = buf;          // Rust takes ownership and frees with free()
+            response->body_len = (uintptr_t)blen;
+        }
+        (*env)->DeleteLocalRef(env, respBody);
+    }
+
+    return 0;
+}
+
 // Native methods implementation
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_C2PA_version(JNIEnv *env, jclass clazz) {
@@ -1420,6 +1498,62 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
         throw_c2pa_exception(env, "Failed to set progress callback");
+        return 0;
+    }
+
+    // Ownership of jctx transfers to the built context (freed in C2PAContext.close()).
+    return (jlong)(uintptr_t)jctx;
+}
+
+JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpResolverNative(JNIEnv *env, jobject obj, jlong builderPtr, jobject bridge) {
+    if (builderPtr == 0 || bridge == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder and HTTP resolver cannot be null");
+        return 0;
+    }
+
+    JavaContextCallback *jctx = (JavaContextCallback*)calloc(1, sizeof(JavaContextCallback));
+    if (jctx == NULL) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
+                         "Failed to allocate HTTP resolver context");
+        return 0;
+    }
+
+    jctx->callback = (*env)->NewGlobalRef(env, bridge);
+    if (jctx->callback == NULL) {
+        free(jctx);
+        check_exception(env);
+        return 0;
+    }
+
+    jclass bridgeClass = (*env)->GetObjectClass(env, bridge);
+    jctx->method = (*env)->GetMethodID(env, bridgeClass, "resolve",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B)Lorg/contentauth/c2pa/HttpResponse;");
+    (*env)->DeleteLocalRef(env, bridgeClass);
+    if (jctx->method == NULL) {
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+        free(jctx);
+        check_exception(env);
+        return 0;
+    }
+
+    jctx->isActive = JNI_TRUE;
+
+    struct C2paHttpResolver *resolver = c2pa_http_resolver_create(jctx, java_http_resolver_callback);
+    if (resolver == NULL) {
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+        free(jctx);
+        throw_c2pa_exception(env, "Failed to create HTTP resolver");
+        return 0;
+    }
+
+    int result = c2pa_context_builder_set_http_resolver((struct C2paContextBuilder*)(uintptr_t)builderPtr, resolver);
+    if (result != 0) {
+        // set_http_resolver only consumes the resolver on success; free it on failure.
+        c2pa_free(resolver);
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+        free(jctx);
+        throw_c2pa_exception(env, "Failed to set HTTP resolver");
         return 0;
     }
 

--- a/library/src/main/kotlin/org/contentauth/c2pa/C2PAContext.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/C2PAContext.kt
@@ -92,6 +92,24 @@ class C2PAContext internal constructor(internal var ptr: Long) : Closeable {
 
         @JvmStatic private external fun nativeNew(): Long
         @JvmStatic private external fun nativeNewWithSettings(settingsPtr: Long): Long
+        @JvmStatic private external fun freeCallbackContextNative(callbackPtr: Long)
+
+        /**
+         * Frees a context-callback (progress / HTTP resolver) struct. Used by
+         * [C2PAContextBuilder] to release callbacks orphaned by a failed or abandoned build.
+         */
+        internal fun releaseCallbackContext(callbackPtr: Long) = freeCallbackContextNative(callbackPtr)
+    }
+
+    /**
+     * Native callback-context pointers (progress / HTTP resolver) owned by this context and freed
+     * on [close]. Populated by [C2PAContextBuilder.build] when callbacks were configured.
+     */
+    private var callbackContextPtrs: LongArray = LongArray(0)
+
+    /** Transfers ownership of callback-context pointers from the builder to this context. */
+    internal fun attachCallbackContexts(ptrs: LongArray) {
+        callbackContextPtrs = ptrs
     }
 
     /**
@@ -114,6 +132,11 @@ class C2PAContext internal constructor(internal var ptr: Long) : Closeable {
         if (ptr != 0L) {
             free(ptr)
             ptr = 0
+        }
+        // Free callback contexts after the context itself, so the core stops invoking them first.
+        if (callbackContextPtrs.isNotEmpty()) {
+            callbackContextPtrs.forEach { freeCallbackContextNative(it) }
+            callbackContextPtrs = LongArray(0)
         }
     }
 

--- a/library/src/main/kotlin/org/contentauth/c2pa/C2PAContextBuilder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/C2PAContextBuilder.kt
@@ -13,6 +13,7 @@ each license.
 package org.contentauth.c2pa
 
 import java.io.Closeable
+import okhttp3.OkHttpClient
 
 /**
  * Mutable builder for assembling a configured [C2PAContext].
@@ -138,6 +139,41 @@ class C2PAContextBuilder internal constructor(private var ptr: Long) : Closeable
     }
 
     /**
+     * Attaches a custom HTTP resolver invoked when the SDK needs to make an HTTP request
+     * (remote-manifest fetch, OCSP, timestamp) on contexts derived from this builder.
+     *
+     * The resolver is called synchronously and is retained until the built [C2PAContext] is closed.
+     *
+     * @param resolver The resolver
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the resolver cannot be attached
+     */
+    @Throws(C2PAError::class)
+    fun setHttpResolver(resolver: HttpResolver): C2PAContextBuilder {
+        if (ptr == 0L) {
+            throw C2PAError.Api("context builder is already consumed")
+        }
+        val callbackPtr = setHttpResolverNative(ptr, HttpResolverBridge(resolver))
+        if (callbackPtr == 0L) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to set HTTP resolver")
+        }
+        callbackContexts.add(callbackPtr)
+        return this
+    }
+
+    /**
+     * Convenience [setHttpResolver] backed by an [OkHttpClient] (defaults to a new client).
+     *
+     * @param client The OkHttp client to perform requests with
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the resolver cannot be attached
+     */
+    @JvmOverloads
+    @Throws(C2PAError::class)
+    fun setHttpResolver(client: OkHttpClient = OkHttpClient()): C2PAContextBuilder =
+        setHttpResolver(OkHttpHttpResolver(client))
+
+    /**
      * Builds an immutable, shareable [C2PAContext] from this builder.
      *
      * The builder is *consumed* by this call and must not be used again; [close] afterward is a
@@ -183,5 +219,6 @@ class C2PAContextBuilder internal constructor(private var ptr: Long) : Closeable
     private external fun setSettingsNative(handle: Long, settingsPtr: Long): Int
     private external fun setSignerNative(handle: Long, signerPtr: Long): Int
     private external fun setProgressCallbackNative(handle: Long, bridge: ProgressCallbackBridge): Long
+    private external fun setHttpResolverNative(handle: Long, bridge: HttpResolverBridge): Long
     private external fun buildNative(handle: Long): Long
 }

--- a/library/src/main/kotlin/org/contentauth/c2pa/C2PAContextBuilder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/C2PAContextBuilder.kt
@@ -43,6 +43,11 @@ import java.io.Closeable
  */
 class C2PAContextBuilder internal constructor(private var ptr: Long) : Closeable {
 
+    // Native callback-context pointers created via setProgressCallback/setHttpResolver.
+    // Ownership transfers to the built C2PAContext on build(); freed here if the builder is
+    // abandoned or the build fails.
+    private val callbackContexts = mutableListOf<Long>()
+
     companion object {
         init {
             loadC2PALibraries()
@@ -109,10 +114,35 @@ class C2PAContextBuilder internal constructor(private var ptr: Long) : Closeable
     }
 
     /**
+     * Attaches a progress observer invoked at checkpoints during signing/reading on contexts (and
+     * the readers/builders) derived from this builder.
+     *
+     * The observer is notification-only; to cancel an in-flight operation call [C2PAContext.cancel].
+     * The observer is retained until the built [C2PAContext] is closed.
+     *
+     * @param observer The progress observer
+     * @return This builder for fluent chaining
+     * @throws C2PAError.Api if the callback cannot be attached
+     */
+    @Throws(C2PAError::class)
+    fun setProgressCallback(observer: ProgressObserver): C2PAContextBuilder {
+        if (ptr == 0L) {
+            throw C2PAError.Api("context builder is already consumed")
+        }
+        val callbackPtr = setProgressCallbackNative(ptr, ProgressCallbackBridge(observer))
+        if (callbackPtr == 0L) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to set progress callback")
+        }
+        callbackContexts.add(callbackPtr)
+        return this
+    }
+
+    /**
      * Builds an immutable, shareable [C2PAContext] from this builder.
      *
      * The builder is *consumed* by this call and must not be used again; [close] afterward is a
-     * safe no-op.
+     * safe no-op. Any callbacks configured on this builder are transferred to the built context and
+     * freed when it is closed.
      *
      * @return The built [C2PAContext]
      * @throws C2PAError.Api if the context cannot be built
@@ -126,9 +156,15 @@ class C2PAContextBuilder internal constructor(private var ptr: Long) : Closeable
         // build() consumes the builder regardless of outcome.
         ptr = 0L
         if (handle == 0L) {
+            // The builder (and its registered callbacks) is gone; free the orphaned callback boxes.
+            callbackContexts.forEach { C2PAContext.releaseCallbackContext(it) }
+            callbackContexts.clear()
             throw C2PAError.Api(C2PA.getError() ?: "Failed to build context")
         }
-        return C2PAContext(handle)
+        val context = C2PAContext(handle)
+        context.attachCallbackContexts(callbackContexts.toLongArray())
+        callbackContexts.clear()
+        return context
     }
 
     override fun close() {
@@ -136,10 +172,16 @@ class C2PAContextBuilder internal constructor(private var ptr: Long) : Closeable
             free(ptr)
             ptr = 0
         }
+        // Free callbacks not transferred to a built context (builder abandoned without build()).
+        if (callbackContexts.isNotEmpty()) {
+            callbackContexts.forEach { C2PAContext.releaseCallbackContext(it) }
+            callbackContexts.clear()
+        }
     }
 
     private external fun free(handle: Long)
     private external fun setSettingsNative(handle: Long, settingsPtr: Long): Int
     private external fun setSignerNative(handle: Long, signerPtr: Long): Int
+    private external fun setProgressCallbackNative(handle: Long, bridge: ProgressCallbackBridge): Long
     private external fun buildNative(handle: Long): Long
 }

--- a/library/src/main/kotlin/org/contentauth/c2pa/HttpResolver.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/HttpResolver.kt
@@ -1,0 +1,92 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+/**
+ * An HTTP request the SDK needs resolved (remote manifest fetch, OCSP, timestamp, etc.),
+ * passed to a [HttpResolver].
+ *
+ * @property url The request URL.
+ * @property method The HTTP method (e.g. "GET", "POST").
+ * @property headers Request headers.
+ * @property body Request body bytes, or `null` if none.
+ */
+data class HttpRequest(
+    val url: String,
+    val method: String,
+    val headers: Map<String, String>,
+    val body: ByteArray?,
+)
+
+/**
+ * The response a [HttpResolver] returns for a [HttpRequest].
+ *
+ * @property status HTTP status code (e.g. 200, 404).
+ * @property body Response body bytes, or `null` if none.
+ */
+data class HttpResponse(val status: Int, val body: ByteArray?)
+
+/**
+ * Resolves HTTP requests the SDK makes during signing/reading. Called synchronously by the core;
+ * implementations should perform the request and return the [HttpResponse], or throw to signal a
+ * failure. Configure via [C2PAContextBuilder.setHttpResolver].
+ */
+fun interface HttpResolver {
+    fun resolve(request: HttpRequest): HttpResponse
+}
+
+/**
+ * Internal adapter invoked from JNI: builds a [HttpRequest] from the native request fields and
+ * forwards to the user's [HttpResolver]. The `resolve(String, String, String, byte[])` signature and
+ * the returned [HttpResponse] are referenced by the native trampoline and must not change without
+ * updating `c2pa_jni.c`.
+ */
+internal class HttpResolverBridge(private val resolver: HttpResolver) {
+    fun resolve(url: String, method: String, headers: String?, body: ByteArray?): HttpResponse =
+        resolver.resolve(HttpRequest(url, method, parseHeaders(headers), body))
+
+    private fun parseHeaders(headers: String?): Map<String, String> {
+        if (headers.isNullOrEmpty()) return emptyMap()
+        val map = LinkedHashMap<String, String>()
+        for (line in headers.split('\n')) {
+            if (line.isBlank()) continue
+            val idx = line.indexOf(':')
+            if (idx > 0) {
+                map[line.substring(0, idx).trim()] = line.substring(idx + 1).trim()
+            }
+        }
+        return map
+    }
+}
+
+/**
+ * [HttpResolver] backed by an [OkHttpClient]. Used by the convenience
+ * [C2PAContextBuilder.setHttpResolver] overload. OkHttp's synchronous `execute()` matches the core's
+ * synchronous resolver contract, so no extra blocking is needed.
+ */
+internal class OkHttpHttpResolver(private val client: OkHttpClient) : HttpResolver {
+    override fun resolve(request: HttpRequest): HttpResponse {
+        val requestBody = request.body?.toRequestBody()
+        val builder = Request.Builder().url(request.url).method(request.method, requestBody)
+        for ((name, value) in request.headers) {
+            builder.addHeader(name, value)
+        }
+        client.newCall(builder.build()).execute().use { response ->
+            return HttpResponse(response.code, response.body?.bytes())
+        }
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/Progress.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Progress.kt
@@ -1,0 +1,73 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa
+
+/**
+ * Phase of a C2PA sign/read operation, reported via [ProgressObserver].
+ *
+ * Mirrors the native `C2paProgressPhase` enum. [UNKNOWN] is a forward-compatibility
+ * fallback for phases added in newer core versions.
+ */
+enum class ProgressPhase(val value: Int) {
+    READING(0),
+    VERIFYING_MANIFEST(1),
+    VERIFYING_SIGNATURE(2),
+    VERIFYING_INGREDIENT(3),
+    VERIFYING_ASSET_HASH(4),
+    ADDING_INGREDIENT(5),
+    THUMBNAIL(6),
+    HASHING(7),
+    SIGNING(8),
+    EMBEDDING(9),
+    FETCHING_REMOTE_MANIFEST(10),
+    WRITING(11),
+    FETCHING_OCSP(12),
+    FETCHING_TIMESTAMP(13),
+    UNKNOWN(-1),
+    ;
+
+    companion object {
+        /** Maps a native phase value to a [ProgressPhase], falling back to [UNKNOWN]. */
+        fun fromValue(value: Int): ProgressPhase = entries.firstOrNull { it.value == value } ?: UNKNOWN
+    }
+}
+
+/**
+ * A single progress notification.
+ *
+ * @property phase The current operation phase.
+ * @property step Monotonically increasing counter within [phase], starting at 1; a liveness signal.
+ * @property total `0` = indeterminate, `1` = single-shot, `> 1` = determinate (`step / total`).
+ */
+data class ProgressUpdate(val phase: ProgressPhase, val step: Long, val total: Long)
+
+/**
+ * Observer notified at progress checkpoints during signing/reading.
+ *
+ * This is an observer only — returning has no effect on the operation. To cancel an in-flight
+ * operation, call [C2PAContext.cancel] from another thread.
+ */
+fun interface ProgressObserver {
+    fun onProgress(update: ProgressUpdate)
+}
+
+/**
+ * Internal adapter invoked from JNI with primitive args; builds a [ProgressUpdate] and forwards it
+ * to the user's [ProgressObserver]. The `onProgress(int, long, long)` signature is referenced by the
+ * native trampoline and must not change without updating `c2pa_jni.c`.
+ */
+internal class ProgressCallbackBridge(private val observer: ProgressObserver) {
+    fun onProgress(phase: Int, step: Long, total: Long) {
+        observer.onProgress(ProgressUpdate(ProgressPhase.fromValue(phase), step, total))
+    }
+}

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -188,6 +188,8 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
     results.add(builderTests.testContextBuilderWithSigner())
+    results.add(builderTests.testContextProgressCallback())
+    results.add(builderTests.testContextHttpResolver())
     results.add(builderTests.testBuilderFromArchive())
     results.add(builderTests.testReaderWithManifestData())
     results.add(builderTests.testJsonRoundTrip())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -26,7 +26,9 @@ import org.contentauth.c2pa.C2PAContextBuilder
 import org.contentauth.c2pa.C2PASettings
 import org.contentauth.c2pa.DigitalSourceType
 import org.contentauth.c2pa.FileStream
+import org.contentauth.c2pa.HttpResponse
 import org.contentauth.c2pa.PredefinedAction
+import org.contentauth.c2pa.ProgressUpdate
 import org.contentauth.c2pa.Reader
 import org.contentauth.c2pa.Signer
 import org.contentauth.c2pa.SignerInfo
@@ -335,6 +337,105 @@ abstract class BuilderTests : TestBase() {
                     "Context builder flow threw",
                     e.toString(),
                 )
+            }
+        }
+    }
+
+    suspend fun testContextProgressCallback(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Context Progress Callback") {
+            val updates = java.util.Collections.synchronizedList(mutableListOf<ProgressUpdate>())
+            try {
+                val certPem = loadResourceAsString("es256_certs")
+                val keyPem = loadResourceAsString("es256_private")
+                val settingsJson =
+                    """{"version": 1, "builder": {"created_assertion_labels": ["c2pa.actions"]}}"""
+
+                val context = C2PASettings.create().use { settings ->
+                    settings.updateFromString(settingsJson, "json")
+                    C2PAContextBuilder.create()
+                        .setSettings(settings)
+                        .setProgressCallback { update -> updates.add(update) }
+                        .build()
+                }
+
+                val signedSize = context.use { ctx ->
+                    Builder.fromContext(ctx).withDefinition(TEST_MANIFEST_JSON).use { builder ->
+                        val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                        ByteArrayStream(sourceImageData).use { source ->
+                            ByteArrayStream().use { dest ->
+                                Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                    builder.sign("image/jpeg", source, dest, signer).size
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val success = signedSize > 0 && updates.isNotEmpty()
+                TestResult(
+                    "Context Progress Callback",
+                    success,
+                    if (success) {
+                        "Observed ${updates.size} progress update(s) during signing"
+                    } else {
+                        "No progress updates received or signing failed"
+                    },
+                    "Signed size: $signedSize, updates: ${updates.size}, phases: ${updates.map { it.phase }.distinct()}",
+                )
+            } catch (e: C2PAError) {
+                TestResult("Context Progress Callback", false, "Progress callback flow threw", e.toString())
+            }
+        }
+    }
+
+    suspend fun testContextHttpResolver(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Context HTTP Resolver") {
+            var invoked = false
+            try {
+                val certPem = loadResourceAsString("es256_certs")
+                val keyPem = loadResourceAsString("es256_private")
+                val settingsJson =
+                    """{"version": 1, "builder": {"created_assertion_labels": ["c2pa.actions"]}}"""
+
+                // A recording resolver: confirms wiring (set → build → transfer → free) doesn't break
+                // normal signing. Actual resolution is exercised on-device with a remote manifest/TSA.
+                val context = C2PASettings.create().use { settings ->
+                    settings.updateFromString(settingsJson, "json")
+                    C2PAContextBuilder.create()
+                        .setSettings(settings)
+                        .setHttpResolver { _ ->
+                            invoked = true
+                            HttpResponse(404, null)
+                        }
+                        .build()
+                }
+
+                val signedSize = context.use { ctx ->
+                    Builder.fromContext(ctx).withDefinition(TEST_MANIFEST_JSON).use { builder ->
+                        val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                        ByteArrayStream(sourceImageData).use { source ->
+                            ByteArrayStream().use { dest ->
+                                Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                    builder.sign("image/jpeg", source, dest, signer).size
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val success = signedSize > 0
+                TestResult(
+                    "Context HTTP Resolver",
+                    success,
+                    if (success) {
+                        "Resolver wired; local sign unaffected (resolver invoked: $invoked)"
+                    } else {
+                        "Signing failed with resolver attached"
+                    },
+                    "Signed size: $signedSize, resolver invoked: $invoked",
+                )
+            } catch (e: C2PAError) {
+                TestResult("Context HTTP Resolver", false, "HTTP resolver flow threw", e.toString())
             }
         }
     }


### PR DESCRIPTION
Part of GP-252 (umbrella). **Stacked on #49 (`feature/gp-254`)** — base retargets to `main` once #49 lands. Maps to iOS GP-292.

Adds the two callback-based context-builder configurations on `C2PAContextBuilder`:

- **Progress** — `setProgressCallback(ProgressObserver)` with a `ProgressPhase` enum (14 phases + UNKNOWN) and `ProgressUpdate(phase, step, total)`. Void observer; cancellation stays unified under `C2PAContext.cancel()` (matches iOS — the FFI's return-to-cancel is not exposed).
- **HTTP resolver** — `setHttpResolver(HttpResolver)` (raw, `HttpRequest`/`HttpResponse` value types) plus an `OkHttpClient`-backed convenience overload (library already depends on okhttp 5.1.0).

**Lifetime:** each callback box is created on the builder, ownership transfers to the built `C2PAContext`, and it's freed on context `close()` (with builder-side cleanup for failed/abandoned builds) — mirrors the existing signer-callback lifecycle.

Linear: https://linear.app/redaranj/issue/GP-263

Verification: JNI C passes `clang -fsyntax-only`; `:library`, `:test-shared`, `:library` androidTest, `:test-app` all compile. **Callbacks are not runtime-validated here** (arm64 container vs x86_64 NDK, no emulator) — the progress + resolver tests need an on-device run; the resolver-invocation path in particular wants a remote-manifest/TSA fixture.