### PR TITLE
GP-305: Expose sign-from-context, modernize settings signer

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
@@ -106,6 +106,12 @@ class AndroidSignerTests : SignerTests() {
     }
 
     @Test
+    fun runTestSignWithContextFromSettings() = runBlocking {
+        val result = testSignWithContextFromSettings()
+        assertTrue(result.success, "Sign With Context (settings signer) test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestSignerFromSettingsToml() = runBlocking {
         val result = testSignerFromSettingsToml()
         assertTrue(result.success, "Signer From Settings (TOML) test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -928,7 +928,80 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *e
     if (result == NULL) {
         check_exception(env);
     }
-    
+
+    return result;
+}
+
+JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr) {
+    if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder, format, and streams cannot be null");
+        return NULL;
+    }
+
+    struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return NULL;
+    }
+
+    struct C2paStream *source = (struct C2paStream*)(uintptr_t)sourceStreamPtr;
+    struct C2paStream *dest = (struct C2paStream*)(uintptr_t)destStreamPtr;
+
+    // Signer comes from the builder's context (programmatic or from settings).
+    const unsigned char *manifestBytes = NULL;
+    int64_t size = c2pa_builder_sign_context(builder, cformat, source, dest, &manifestBytes);
+
+    release_cstring(env, format, cformat);
+
+    if (size < 0) {
+        throw_c2pa_exception(env, "Failed to sign builder with context");
+        return NULL;
+    }
+
+    jclass resultClass = g_signResultClass;
+    if (resultClass == NULL) {
+        resultClass = (*env)->FindClass(env, "org/contentauth/c2pa/Builder$SignResult");
+        if (resultClass == NULL) {
+            check_exception(env);
+            if (manifestBytes != NULL) {
+                c2pa_free(manifestBytes);
+            }
+            return NULL;
+        }
+    }
+
+    jmethodID constructor = (*env)->GetMethodID(env, resultClass, "<init>", "(J[B)V");
+    if (constructor == NULL) {
+        check_exception(env);
+        if (manifestBytes != NULL) {
+            c2pa_free(manifestBytes);
+        }
+        return NULL;
+    }
+
+    jbyteArray jmanifestBytes = NULL;
+    if (manifestBytes != NULL && size > 0) {
+        jmanifestBytes = safe_new_byte_array(env, size);
+        if (jmanifestBytes == NULL) {
+            c2pa_free(manifestBytes);
+            return NULL;
+        }
+
+        (*env)->SetByteArrayRegion(env, jmanifestBytes, 0, size, (const jbyte*)manifestBytes);
+        if (check_exception(env)) {
+            c2pa_free(manifestBytes);
+            return NULL;
+        }
+
+        c2pa_free(manifestBytes);
+    }
+
+    jobject result = (*env)->NewObject(env, resultClass, constructor, (jlong)size, jmanifestBytes);
+    if (result == NULL) {
+        check_exception(env);
+    }
+
     return result;
 }
 

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -496,6 +496,30 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
     }
 
     /**
+     * Signs the manifest using the signer configured on the builder's [C2PAContext] — either set
+     * programmatically (`C2PAContextBuilder.setSigner`) or supplied via settings (`[signer.local]`
+     * / `[cawg_x509_signer]`) — and writes the signed asset to [dest].
+     *
+     * Unlike [sign], no explicit [Signer] is passed; the builder must have been created via
+     * [Builder.fromContext] with a context that has a signer, or signing fails. This is the
+     * non-deprecated way to sign with a settings-configured signer.
+     *
+     * @param format The MIME type of the asset (e.g. "image/jpeg")
+     * @param source The input stream containing the original asset
+     * @param dest The output stream for the signed asset
+     * @return A [SignResult] containing the manifest size and optional manifest bytes
+     * @throws C2PAError.Api if signing fails (e.g. the context has no signer)
+     */
+    @Throws(C2PAError::class)
+    fun signWithContext(format: String, source: Stream, dest: Stream): SignResult {
+        val result = signWithContextNative(ptr, format, source.rawPtr, dest.rawPtr)
+        if (result.size < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to sign with context")
+        }
+        return result
+    }
+
+    /**
      * Creates a data-hashed placeholder for deferred signing workflows.
      *
      * This generates a placeholder manifest that can be embedded in an asset before
@@ -578,6 +602,12 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         sourceHandle: Long,
         destHandle: Long,
         signerHandle: Long,
+    ): SignResult
+    private external fun signWithContextNative(
+        handle: Long,
+        format: String,
+        sourceHandle: Long,
+        destHandle: Long,
     ): SignResult
     private external fun dataHashedPlaceholderNative(handle: Long, reservedSize: Long, format: String): ByteArray?
     private external fun signDataHashedEmbeddableNative(

--- a/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
@@ -108,6 +108,11 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * }
          * ```
          */
+        @Deprecated(
+            "Settings-based signers rely on deprecated core APIs (c2pa_load_settings / " +
+                "c2pa_signer_from_settings). Configure the signer in C2PASettings, build a " +
+                "C2PAContext, and sign via Builder.signWithContext(). See GP-305.",
+        )
         @JvmStatic
         @Throws(C2PAError::class)
         fun fromSettingsJson(settingsJson: String): Signer =
@@ -154,6 +159,11 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * referenced_assertions = ["cawg.training-mining"]
          * ```
          */
+        @Deprecated(
+            "Settings-based signers rely on deprecated core APIs (c2pa_load_settings / " +
+                "c2pa_signer_from_settings). Configure the signer in C2PASettings, build a " +
+                "C2PAContext, and sign via Builder.signWithContext(). See GP-305.",
+        )
         @JvmStatic
         @Throws(C2PAError::class)
         fun fromSettingsToml(settingsToml: String): Signer =
@@ -189,6 +199,10 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * @param format The format of the settings string ("json" or "toml").
          * @throws C2PAError if the settings are invalid.
          */
+        @Deprecated(
+            "Global settings apply relies on the deprecated c2pa_load_settings. Configure settings " +
+                "in C2PASettings and build a C2PAContext instead. See GP-305.",
+        )
         @JvmStatic
         @Throws(C2PAError::class)
         fun loadSettings(settings: String, format: String) {

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -206,6 +206,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(signerTests.testStrongBoxSignerIntegration())
     results.add(signerTests.testKeyStoreSignerKeyManagement())
     results.add(signerTests.testStrongBoxAvailability())
+    results.add(signerTests.testSignWithContextFromSettings())
     results.add(signerTests.testSignerFromSettingsToml())
     results.add(signerTests.testSignerFromSettingsJson())
 

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.withContext
 import org.contentauth.c2pa.Builder
 import org.contentauth.c2pa.ByteArrayStream
 import org.contentauth.c2pa.C2PA
+import org.contentauth.c2pa.C2PAContext
+import org.contentauth.c2pa.C2PASettings
 import org.contentauth.c2pa.CertificateManager
 import org.contentauth.c2pa.FileStream
 import org.contentauth.c2pa.KeyStoreSigner
@@ -794,6 +796,51 @@ abstract class SignerTests : TestBase() {
         }
     }
 
+    suspend fun testSignWithContextFromSettings(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Sign With Context (settings signer)") {
+            try {
+                val settingsToml = loadSharedResourceAsString("test_settings_with_cawg_signing.toml")
+                    ?: throw IllegalArgumentException("Resource not found: test_settings_with_cawg_signing.toml")
+                val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+
+                // settings (carrying [signer.local]) -> context -> builder -> signWithContext:
+                // the non-deprecated path that draws the signer from the context.
+                val signedSize = C2PASettings.create().use { settings ->
+                    settings.updateFromString(settingsToml, "toml")
+                    C2PAContext.fromSettings(settings).use { context ->
+                        Builder.fromContext(context).withDefinition(TEST_MANIFEST_JSON).use { builder ->
+                            ByteArrayStream(sourceImageData).use { source ->
+                                ByteArrayStream().use { dest ->
+                                    builder.signWithContext("image/jpeg", source, dest).size
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val success = signedSize > 0
+                TestResult(
+                    "Sign With Context (settings signer)",
+                    success,
+                    if (success) {
+                        "Signed via the context's settings-configured signer"
+                    } else {
+                        "signWithContext produced no manifest"
+                    },
+                    "Signed size: $signedSize",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "Sign With Context (settings signer)",
+                    false,
+                    "signWithContext flow threw",
+                    e.toString(),
+                )
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
     suspend fun testSignerFromSettingsToml(): TestResult = withContext(Dispatchers.IO) {
         runTest("Signer From Settings (TOML)") {
             try {
@@ -875,6 +922,7 @@ abstract class SignerTests : TestBase() {
         }
     }
 
+    @Suppress("DEPRECATION")
     suspend fun testSignerFromSettingsJson(): TestResult = withContext(Dispatchers.IO) {
         runTest("Signer From Settings (JSON)") {
             try {


### PR DESCRIPTION
Part of GP-252 (umbrella). Exposes the non-deprecated context-based signing entry point and steers the settings-signer workflow onto it.

- **`Builder.signWithContext(format, source, dest)`** over `c2pa_builder_sign_context` — signs using the signer on the builder's context (set programmatically via `C2PAContextBuilder.setSigner`, or supplied via `C2PASettings` `[signer.local]`/`[cawg_x509_signer]`). No explicit `Signer`. (`sign_context` had slipped through GP-252.)
- **Deprecated** `Signer.fromSettingsJson`/`fromSettingsToml`/`loadSettings` — they rely on the deprecated `c2pa_load_settings` + `c2pa_signer_from_settings`; the message points at the context path. They keep working (both survive 0.88.0).
- **Test:** settings -> `C2PAContext.fromSettings` -> `Builder.fromContext` -> `signWithContext`, asserting the context signs with its settings-configured signer. Existing settings-signer tests get `@Suppress(\"DEPRECATION\")`.

Independent of the other branches (uses only `C2PAContext.fromSettings` + `Builder.fromContext`, already on main).

Linear: https://linear.app/redaranj/issue/GP-305

Verification: JNI C passes `clang -fsyntax-only`; `:library`, `:test-shared`, `:library` androidTest, `:test-app` all compile. The settings-signer→context→signWithContext path needs an on-device run to confirm the context picks up the settings signer.