### PR TITLE
GP-253: Bump core C2PA SDK to v0.88.0

### DIFF
--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,3 +1,3 @@
 # C2PA Native Library Version
 # Update this to use a different release from https://github.com/contentauth/c2pa-rs/releases
-c2paVersion=v0.84.1
+c2paVersion=v0.88.0


### PR DESCRIPTION
Part of GP-252 (umbrella). **Stacked on #43 (`feature/gp-261`)** — base retargets to `main` once #43 lands. The version gate for the rollout (GP-304 Wave 4).

Sets `c2paVersion=v0.88.0` in `library/gradle.properties`. The bundled `library/src/main/jni/c2pa.h` is **gitignored / build-generated** — `make download-binaries` re-downloads the 0.88.0 c-ffi and refreshes+patches the header from the release zip, so this PR is just the one-line version pin.

**Why it must follow GP-261:** 0.88.0 removes `c2pa_read_file`/`c2pa_read_ingredient_file`/`c2pa_sign_file` (+ unused `builder_sign_to_stream`); GP-261 already migrated off them, so the JNI references no removed symbols.

Linear: https://linear.app/redaranj/issue/GP-253

Verification here: the JNI C source compiles clean against the 0.88.0 header (`clang -fsyntax-only`) with zero references to the removed symbols. **The native `.so` re-download + link + full instrumented test run must be done in a real Android toolchain** (this container is arm64 vs an x86_64 NDK) — please rebuild and run the suite before merging.