### PR TITLE
GP-262: Expose reader crJSON output

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -70,6 +70,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestReaderCrJson() = runBlocking {
+        val result = testReaderCrJson()
+        assertTrue(result.success, "Reader crJSON test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestBuilderFromArchive() = runBlocking {
         val result = testBuilderFromArchive()
         assertTrue(result.success, "Builder from Archive test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -629,6 +629,26 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toDetailedJsonNative(
     return result;
 }
 
+JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_crjsonNative(JNIEnv *env, jobject obj, jlong readerPtr) {
+    if (readerPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"),
+                         "Reader is not initialized");
+        return NULL;
+    }
+
+    struct C2paReader *reader = (struct C2paReader*)(uintptr_t)readerPtr;
+    char *json = c2pa_reader_crjson(reader);
+
+    if (json == NULL) {
+        throw_c2pa_exception(env, "Failed to generate crJSON from reader");
+        return NULL;
+    }
+
+    jstring result = cstring_to_jstring(env, json);
+    c2pa_free(json);
+    return result;
+}
+
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_remoteUrlNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 

--- a/library/src/main/kotlin/org/contentauth/c2pa/Reader.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Reader.kt
@@ -287,6 +287,27 @@ class Reader internal constructor(private var ptr: Long) : Closeable {
     }
 
     /**
+     * Returns the manifest as a crJSON string (new in c2pa-rs 0.88.0).
+     *
+     * crJSON is an alternative JSON serialization of the manifest store. Use [json] for the
+     * standard representation or [detailedJson] for the verbose one.
+     *
+     * @return The manifest as a crJSON string
+     * @throws C2PAError.Api if the manifest cannot be serialized
+     *
+     * @see json
+     * @see detailedJson
+     */
+    @Throws(C2PAError::class)
+    fun crJSON(): String {
+        val json = crjsonNative(ptr)
+        if (json == null) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to convert to crJSON")
+        }
+        return json
+    }
+
+    /**
      * Returns the remote URL where the manifest is hosted, if available.
      *
      * This method returns the URL specified when the manifest was created with
@@ -385,6 +406,7 @@ class Reader internal constructor(private var ptr: Long) : Closeable {
     private external fun withFragmentNative(handle: Long, format: String, streamHandle: Long, fragmentHandle: Long): Long
     private external fun toJsonNative(handle: Long): String?
     private external fun toDetailedJsonNative(handle: Long): String?
+    private external fun crjsonNative(handle: Long): String?
     private external fun remoteUrlNative(handle: Long): String?
     private external fun isEmbeddedNative(handle: Long): Boolean
     private external fun resourceToStreamNative(handle: Long, uri: String, streamHandle: Long): Long

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -185,6 +185,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderRemoteUrl())
     results.add(builderTests.testBuilderAddResource())
     results.add(builderTests.testBuilderAddIngredient())
+    results.add(builderTests.testReaderCrJson())
     results.add(builderTests.testBuilderFromArchive())
     results.add(builderTests.testReaderWithManifestData())
     results.add(builderTests.testJsonRoundTrip())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -284,6 +284,47 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testReaderCrJson(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Reader crJSON") {
+            try {
+                val certPem = loadResourceAsString("es256_certs")
+                val keyPem = loadResourceAsString("es256_private")
+                val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+
+                val signedData = Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                    ByteArrayStream(sourceImageData).use { source ->
+                        ByteArrayStream().use { dest ->
+                            Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                builder.sign("image/jpeg", source, dest, signer)
+                            }
+                            dest.getData()
+                        }
+                    }
+                }
+
+                val crjson = ByteArrayStream(signedData).use { signedStream ->
+                    Reader.fromStream("image/jpeg", signedStream).use { reader ->
+                        reader.crJSON()
+                    }
+                }
+
+                val success = crjson.isNotEmpty()
+                TestResult(
+                    "Reader crJSON",
+                    success,
+                    if (success) {
+                        "crJSON returned ${crjson.length} chars"
+                    } else {
+                        "crJSON was empty"
+                    },
+                    "crJSON length: ${crjson.length}",
+                )
+            } catch (e: C2PAError) {
+                TestResult("Reader crJSON", false, "crJSON flow threw", e.toString())
+            }
+        }
+    }
+
     suspend fun testBuilderFromArchive(): TestResult = withContext(Dispatchers.IO) {
         runTest("Builder from Archive") {
             val manifestJson = TEST_MANIFEST_JSON


### PR DESCRIPTION
Part of GP-252 (umbrella). **Stacked on #53 (`feature/gp-253`)** — base retargets to `main` once the bump lands. Rides with the v0.88.0 bump (GP-304 Wave 4).

Adds `Reader.crJSON()` over `c2pa_reader_crjson` (new in c2pa-rs 0.88.0), alongside `json()`/`detailedJson()`; the JNI frees the returned string with `c2pa_free`. Shared sign→read→crJSON test added.

**Requires the 0.88.0 bump** for the symbol — hence stacked on #53 (the symbol does not exist in 0.85.2).

Linear: https://linear.app/redaranj/issue/GP-262

Verification: JNI C compiles against the 0.88.0 header (`clang -fsyntax-only`); `:library`, `:test-shared`, `:library` androidTest, `:test-app` all compile. Native `.so` + the crJSON test run need the 0.88.0 binary on a real toolchain/device.