### PR TITLE
feat: Sign from Context

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
@@ -106,6 +106,12 @@ class AndroidSignerTests : SignerTests() {
     }
 
     @Test
+    fun runTestSignWithContextFromSettings() = runBlocking {
+        val result = testSignWithContextFromSettings()
+        assertTrue(result.success, "Sign With Context (settings signer) test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestSignerFromSettingsToml() = runBlocking {
         val result = testSignerFromSettingsToml()
         assertTrue(result.success, "Signer From Settings (TOML) test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -1104,7 +1104,80 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *e
     if (result == NULL) {
         check_exception(env);
     }
-    
+
+    return result;
+}
+
+JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr) {
+    if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0) {
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Builder, format, and streams cannot be null");
+        return NULL;
+    }
+
+    struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
+    const char *cformat = jstring_to_cstring(env, format);
+    if (cformat == NULL) {
+        return NULL;
+    }
+
+    struct C2paStream *source = (struct C2paStream*)(uintptr_t)sourceStreamPtr;
+    struct C2paStream *dest = (struct C2paStream*)(uintptr_t)destStreamPtr;
+
+    // Signer comes from the builder's context (programmatic or from settings).
+    const unsigned char *manifestBytes = NULL;
+    int64_t size = c2pa_builder_sign_context(builder, cformat, source, dest, &manifestBytes);
+
+    release_cstring(env, format, cformat);
+
+    if (size < 0) {
+        throw_c2pa_exception(env, "Failed to sign builder with context");
+        return NULL;
+    }
+
+    jclass resultClass = g_signResultClass;
+    if (resultClass == NULL) {
+        resultClass = (*env)->FindClass(env, "org/contentauth/c2pa/Builder$SignResult");
+        if (resultClass == NULL) {
+            check_exception(env);
+            if (manifestBytes != NULL) {
+                c2pa_free(manifestBytes);
+            }
+            return NULL;
+        }
+    }
+
+    jmethodID constructor = (*env)->GetMethodID(env, resultClass, "<init>", "(J[B)V");
+    if (constructor == NULL) {
+        check_exception(env);
+        if (manifestBytes != NULL) {
+            c2pa_free(manifestBytes);
+        }
+        return NULL;
+    }
+
+    jbyteArray jmanifestBytes = NULL;
+    if (manifestBytes != NULL && size > 0) {
+        jmanifestBytes = safe_new_byte_array(env, size);
+        if (jmanifestBytes == NULL) {
+            c2pa_free(manifestBytes);
+            return NULL;
+        }
+
+        (*env)->SetByteArrayRegion(env, jmanifestBytes, 0, size, (const jbyte*)manifestBytes);
+        if (check_exception(env)) {
+            c2pa_free(manifestBytes);
+            return NULL;
+        }
+
+        c2pa_free(manifestBytes);
+    }
+
+    jobject result = (*env)->NewObject(env, resultClass, constructor, (jlong)size, jmanifestBytes);
+    if (result == NULL) {
+        check_exception(env);
+    }
+
     return result;
 }
 

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -585,6 +585,30 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
     }
 
     /**
+     * Signs the manifest using the signer configured on the builder's [C2PAContext] — either set
+     * programmatically (`C2PAContextBuilder.setSigner`) or supplied via settings (`[signer.local]`
+     * / `[cawg_x509_signer]`) — and writes the signed asset to [dest].
+     *
+     * Unlike [sign], no explicit [Signer] is passed; the builder must have been created via
+     * [Builder.fromContext] with a context that has a signer, or signing fails. This is the
+     * non-deprecated way to sign with a settings-configured signer.
+     *
+     * @param format The MIME type of the asset (e.g. "image/jpeg")
+     * @param source The input stream containing the original asset
+     * @param dest The output stream for the signed asset
+     * @return A [SignResult] containing the manifest size and optional manifest bytes
+     * @throws C2PAError.Api if signing fails (e.g. the context has no signer)
+     */
+    @Throws(C2PAError::class)
+    fun signWithContext(format: String, source: Stream, dest: Stream): SignResult {
+        val result = signWithContextNative(ptr, format, source.rawPtr, dest.rawPtr)
+        if (result.size < 0) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to sign with context")
+        }
+        return result
+    }
+
+    /**
      * Creates a data-hashed placeholder for deferred signing workflows.
      *
      * This generates a placeholder manifest that can be embedded in an asset before
@@ -815,6 +839,12 @@ class Builder internal constructor(private var ptr: Long) : Closeable {
         sourceHandle: Long,
         destHandle: Long,
         signerHandle: Long,
+    ): SignResult
+    private external fun signWithContextNative(
+        handle: Long,
+        format: String,
+        sourceHandle: Long,
+        destHandle: Long,
     ): SignResult
     private external fun dataHashedPlaceholderNative(handle: Long, reservedSize: Long, format: String): ByteArray?
     private external fun signDataHashedEmbeddableNative(

--- a/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
@@ -116,6 +116,11 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * }
          * ```
          */
+        @Deprecated(
+            "Settings-based signers rely on deprecated core APIs (c2pa_load_settings / " +
+                "c2pa_signer_from_settings). Configure the signer in C2PASettings, build a " +
+                "C2PAContext, and sign via Builder.signWithContext(). See GP-305.",
+        )
         @JvmStatic
         @Throws(C2PAError::class)
         fun fromSettingsJson(settingsJson: String): Signer = fromSettings(settingsJson, "json")
@@ -161,6 +166,11 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * referenced_assertions = ["cawg.training-mining"]
          * ```
          */
+        @Deprecated(
+            "Settings-based signers rely on deprecated core APIs (c2pa_load_settings / " +
+                "c2pa_signer_from_settings). Configure the signer in C2PASettings, build a " +
+                "C2PAContext, and sign via Builder.signWithContext(). See GP-305.",
+        )
         @JvmStatic
         @Throws(C2PAError::class)
         fun fromSettingsToml(settingsToml: String): Signer = fromSettings(settingsToml, "toml")
@@ -195,6 +205,10 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * @param format The format of the settings string ("json" or "toml").
          * @throws C2PAError if the settings are invalid.
          */
+        @Deprecated(
+            "Global settings apply relies on the deprecated c2pa_load_settings. Configure settings " +
+                "in C2PASettings and build a C2PAContext instead. See GP-305.",
+        )
         @JvmStatic
         @Throws(C2PAError::class)
         fun loadSettings(settings: String, format: String) {

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -225,6 +225,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(signerTests.testStrongBoxSignerIntegration())
     results.add(signerTests.testKeyStoreSignerKeyManagement())
     results.add(signerTests.testStrongBoxAvailability())
+    results.add(signerTests.testSignWithContextFromSettings())
     results.add(signerTests.testSignerFromSettingsToml())
     results.add(signerTests.testSignerFromSettingsJson())
     results.add(signerTests.testCawgCombinedPemSigner())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
@@ -24,7 +24,9 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.contentauth.c2pa.Builder
 import org.contentauth.c2pa.ByteArrayStream
 import org.contentauth.c2pa.C2PA
+import org.contentauth.c2pa.C2PAContext
 import org.contentauth.c2pa.C2PAError
+import org.contentauth.c2pa.C2PASettings
 import org.contentauth.c2pa.CertificateManager
 import org.contentauth.c2pa.FileStream
 import org.contentauth.c2pa.KeyStoreSigner
@@ -802,6 +804,51 @@ abstract class SignerTests : TestBase() {
         }
     }
 
+    suspend fun testSignWithContextFromSettings(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Sign With Context (settings signer)") {
+            try {
+                val settingsToml = loadSharedResourceAsString("test_settings_with_cawg_signing.toml")
+                    ?: throw IllegalArgumentException("Resource not found: test_settings_with_cawg_signing.toml")
+                val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+
+                // settings (carrying [signer.local]) -> context -> builder -> signWithContext:
+                // the non-deprecated path that draws the signer from the context.
+                val signedSize = C2PASettings.create().use { settings ->
+                    settings.updateFromString(settingsToml, "toml")
+                    C2PAContext.fromSettings(settings).use { context ->
+                        Builder.fromContext(context).withDefinition(TEST_MANIFEST_JSON).use { builder ->
+                            ByteArrayStream(sourceImageData).use { source ->
+                                ByteArrayStream().use { dest ->
+                                    builder.signWithContext("image/jpeg", source, dest).size
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val success = signedSize > 0
+                TestResult(
+                    "Sign With Context (settings signer)",
+                    success,
+                    if (success) {
+                        "Signed via the context's settings-configured signer"
+                    } else {
+                        "signWithContext produced no manifest"
+                    },
+                    "Signed size: $signedSize",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "Sign With Context (settings signer)",
+                    false,
+                    "signWithContext flow threw",
+                    e.toString(),
+                )
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
     suspend fun testSignerFromSettingsToml(): TestResult = withContext(Dispatchers.IO) {
         runTest("Signer From Settings (TOML)") {
             try {
@@ -883,6 +930,7 @@ abstract class SignerTests : TestBase() {
         }
     }
 
+    @Suppress("DEPRECATION")
     suspend fun testSignerFromSettingsJson(): TestResult = withContext(Dispatchers.IO) {
         runTest("Signer From Settings (JSON)") {
             try {


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->

Adds Builder.signWithContext(format, source, dest), which signs using the signer configured on the builder's context, whether set programmatically via C2PAContextBuilder.setSigner or supplied through settings. Deprecates Signer.fromSettingsJson/fromSettingsToml/loadSettings in favor of this context path, since they rely on FFI the upstream library has deprecated.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment